### PR TITLE
Remove unneeded proxy config for m-dot dev server

### DIFF
--- a/templates/etc/apache2/sites-enabled/local.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/local.permanent.conf
@@ -81,13 +81,6 @@
         RewriteRule ^(.*)$ index.html [L,QSA]
     </Directory>
 
-    #local only for mdot
-    ProxyPass /sockjs-node/ http://10.0.2.2:4200/sockjs-node/
-    ProxyPassReverse /sockjs-node/ http://10.0.2.2:4200/sockjs-node/
-    ProxyPass /mdev/ http://10.0.2.2:4200/
-    ProxyPreserveHost On
-    ProxyStatus On
-
     <Directory "/data/www/website">
         Require all granted
         RewriteBase /


### PR DESCRIPTION
Finally need to do some development against the local environment, and have determined that this old proxy method configuration isn't necessary, so I'm nuking it!