### PR TITLE
Split AWS build and app keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,7 @@ jobs:
           env:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            DEV_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+            DEV_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
             AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
             HOST: dev

--- a/images/dev.json
+++ b/images/dev.json
@@ -3,8 +3,8 @@
       "environment": "dev",
       "templates_path": "/tmp/templates",
       "aws_region": "{{env `AWS_REGION`}}",
-      "aws_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-      "aws_secret": "{{env `AWS_SECRET_ACCESS_KEY`}}"
+      "aws_key": "{{env `DEV_AWS_ACCESS_KEY_ID`}}",
+      "aws_secret": "{{env `DEV_AWS_SECRET_ACCESS_KEY`}}"
     },
     "builders": [
       {


### PR DESCRIPTION
Use the build key for building, but inject a separate, more restricted application key into the build environment.