### PR TITLE
Add Sentry to upload-service

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,4 @@ export AWS_ACCESS_KEY_ID="tHiSiSyOuRAcCeSsKeY"
 export AWS_SECRET_ACCESS_KEY="tHiSiSyOuRAcCeSsSeCrEt"
 export AWS_REGION=us-east-1
 export HOST=local
+export UPLOAD_SERVICE_SENTRY_DSN="https://EXAMPLE@EXAMPLE.ingest.sentry.io/EXAMPLE"

--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -63,7 +63,7 @@ a2enconf charset
 a2enconf other-vhosts-access-log
 
 echo "Configure Upload Service"
-cp $TEMPLATES_PATH/etc/systemd/system/node-upload.service /etc/systemd/system/node-upload.service
+envsubst < $TEMPLATES_PATH/etc/systemd/system/node-upload.service > /etc/systemd/system/node-upload.service
 systemctl enable node-upload.service
 
 echo "Install node global packages"

--- a/templates/etc/systemd/system/node-upload.service
+++ b/templates/etc/systemd/system/node-upload.service
@@ -10,6 +10,10 @@ KillMode=process
 Restart=always
 User=www-data
 Group=www-data
+Environment="SENTRY_ENVIRONMENT=${PERM_ENV}"
+Environment="PORT=3000"
+Environment="SENTRY_DSN=${UPLOAD_SERVICE_SENTRY_DSN}"
+Environment="AWS_SDK_LOAD_CONFIG=true"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description
This PR adds Sentry configuration for the upload service.

It also sneaks in a fix where AWS region was not being properly set.

Resolves #9