### PR TITLE
Use /app as base url for mdot app

### DIFF
--- a/templates/etc/apache2/sites-enabled/dev.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/dev.permanent.conf
@@ -78,11 +78,11 @@
     </Directory>
 
 	AliasMatch ^/preview(.*) /data/www/api/preview.php$1
-	RewriteRule ^/app$ /m/app [L,R=302]
-	RewriteRule ^/app/(.*)$ /m/$1 [L,R=302]
-    Alias /m /data/www/mdot/dist/mdot
+    RewriteRule ^/m$ /app [L,R=302]
+    RewriteRule ^/m/(.*)$ /app/$1 [L,R=302]
+    Alias /app /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
-	Alias /share /data/www/mdot/dist/mdot
+    Alias /share /data/www/mdot/dist/mdot
     <Directory "/data/www/mdot/dist/mdot">
         Require all granted
         Options FollowSymLinks

--- a/templates/etc/apache2/sites-enabled/local.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/local.permanent.conf
@@ -65,9 +65,9 @@
         Require all granted
     </Directory>
 
-    RewriteRule ^/app$ /m/app [L,R=302]
-    RewriteRule ^/app/(.*)$ /m/$1 [L,R=302]
-    Alias /m /data/www/mdot/dist/mdot
+    RewriteRule ^/m$ /app [L,R=302]
+    RewriteRule ^/m/(.*)$ /app/$1 [L,R=302]
+    Alias /app /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     <Directory "/data/www/mdot/dist/mdot">


### PR DESCRIPTION
Two changes here, basically swapping the redirect:
- Redirect from /m to /app for any old URLs
- Sets /app as as a main alias for the mdot path