### PR TITLE
Explicitly disable SSH password authentication

### DIFF
--- a/provisioners/setup.yml
+++ b/provisioners/setup.yml
@@ -35,6 +35,7 @@
       LoginGraceTime: 20
       AllowAgentForwarding: no
       AllowTcpForwarding: no
+      PasswordAuthentication: no
   roles:
     - role: willshersystems.sshd
 


### PR DESCRIPTION
Looks like this is not disabled by default.