### PR TITLE
Add `npm` module from ansible-galaxy and run `npm install`

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build image
         run: |
-          ansible-galaxy install willshersystems.sshd
+          ansible-galaxy install willshersystems.sshd 
+          ansible-galaxy install community.general.npm
           cd images
           packer build -var-file=${{ matrix.machine }}.json image.json
         env:

--- a/provisioners/deploy-backend.yml
+++ b/provisioners/deploy-backend.yml
@@ -38,6 +38,10 @@
         - task-runner
         - upload-service
         - website
+    - name: Install upload-service dependencies
+      community.general.npm:
+        path: /data/www/upload-service
+        production: yes
     - name: Change file permissions
       file:
         path: /data/www


### PR DESCRIPTION
Using the `community.general.npm` step to run `npm install` for `upload-service` requires installation from `ansible-galaxy` during the image build.

May have to just run a test image build to see if it works!

Closes #40 