### PR TITLE
Use `collection` syntax for `community.general`

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build image
         run: |
           ansible-galaxy install willshersystems.sshd 
-          ansible-galaxy install community.general.npm
+          ansible-galaxy collection install community.general
           cd images
           packer build -var-file=${{ matrix.machine }}.json image.json
         env:


### PR DESCRIPTION
Fixing broken syntax installing the appropriate collection for the `npm install` step