### PR TITLE
Pin Ubuntu image version to 18.04

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         machine: [backend, cron, taskrunner]
@@ -16,7 +16,7 @@ jobs:
           cd images
           packer validate -var-file=${{ matrix.machine }}.json image.json
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: ["validate"]
     strategy:
       matrix:
@@ -48,7 +48,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_TOKEN }}
           PERM_ENV: ${{ matrix.environment.perm_env }}
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: ["build"]
     steps:
       - name: Send Slack notification

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         machine: [backend, cron, taskrunner]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
     - name: Configure AWS Credentials

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         machine: [backend, cron, taskrunner]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
     - name: Configure AWS Credentials

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         machine: [backend, cron, taskrunner]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
     - name: Configure AWS Credentials


### PR DESCRIPTION
GitHub will soon be updating the version of Ubuntu pointed to by `ubuntu-latest`; currently, it points to 18.04, and soon it will point
to 20.04. This upgrade does come with several version changes, including to Ansible, and may break our build.

While I don't think we're doing anything particularly complicated in these build scripts, pinning the version will allow us to upgrade in our own time rather than in response to a broken build.

Issue #47 Upgrade Ubuntu version used for building