### PR TITLE
Document environment variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,43 @@
-export AWS_ACCESS_KEY_ID="tHiSiSyOuRAcCeSsKeY"
-export AWS_SECRET_ACCESS_KEY="tHiSiSyOuRAcCeSsSeCrEt"
-export DEV_AWS_ACCESS_KEY_ID="tHiSiSyOuRdEvAcCeSsKeY"
-export DEV_AWS_SECRET_ACCESS_KEY="tHiSiSyOuRdEvAcCeSsSeCrEt"
+# Deploy AWS credentials
+# These credentials are used by Packer to build the AMI
+# See the item "AWS Github/Terraform build access key" in Bitwarden
+export DEPLOY_AWS_ACCESS_KEY_ID="tHiSiSyOuRAcCeSsKeY"
+export DEPLOY_AWS_SECRET_ACCESS_KEY="tHiSiSyOuRAcCeSsSeCrEt"
+
+# Application AWS credentials
+# These credentials are baked into the image to be used by the application
+# TODO: document what permissions this key needs. In the meantime, using the
+# same credentials as used for deploying will at least allow an image to be
+# built, although the application may or may not work.
+export AWS_ACCESS_KEY_ID=$DEPLOY_AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+
+# This is a non-standard name used in this repo;
+# it is tech debt and should be cleaned up to use the standard name
+export AWS_ACCESS_SECRET=$AWS_SECRET_ACCESS_KEY
+
+# These are only used by GitHub Actions, and use secrets of the same names
+# configured on GitHub; they are listed here only for the sake of completeness
+# and can be left blank
+export DEV_AWS_ACCESS_KEY_ID=
+export DEV_AWS_SECRET_ACCESS_KEY=
+export STAGING_AWS_ACCESS_KEY_ID=
+export STAGING_AWS_SECRET_ACCESS_KEY=
+export PROD_AWS_ACCESS_KEY_ID=
+export PROD_AWS_SECRET_ACCESS_KEY=
+
+# AWS Region
+# For developers, it is easier to clean up if you use a different region than
+# we do for everything else; note that you'll need to switch regions in the
+# console to see your AMI
+# See also https://docs.aws.amazon.com/general/latest/gr/rande.html
 export AWS_REGION=us-east-1
+
+# Permanent environment name; must be one of [local, dev, staging, prod].
+# For developers, keep this as dev.
 export PERM_ENV=dev
+
+# Sentry DSN
+# Get this from Sentry. If the upload-service receives an empty string, it will
+# leave its Sentry integration unconfigured.
 export UPLOAD_SERVICE_SENTRY_DSN="https://EXAMPLE@EXAMPLE.ingest.sentry.io/EXAMPLE"

--- a/.env.template
+++ b/.env.template
@@ -37,7 +37,8 @@ export AWS_REGION=us-east-1
 # For developers, keep this as dev.
 export PERM_ENV=dev
 
-# Sentry DSN
-# Get this from Sentry. If the upload-service receives an empty string, it will
+# Sentry DSN for upload-service
+# Get this from Sentry: project > settings > "Client Keys (DSN)" > DSN.
+# If the upload-service receives an empty string, it will
 # leave its Sentry integration unconfigured.
-export UPLOAD_SERVICE_SENTRY_DSN="https://EXAMPLE@EXAMPLE.ingest.sentry.io/EXAMPLE"
+export SENTRY_DSN="https://EXAMPLE@EXAMPLE.ingest.sentry.io/EXAMPLE"


### PR DESCRIPTION
The hardest part of setting up Packer to build locally was figuring out what environment variables I needed, and what values I should use. Now that I've figured that out, document what I've learned so that others will have an easier time of it.

@cecilia-donnelly, @mithuna, I think it would be worthwhile for you to make sure you can run Packer locally to create an AMI! The README has really good documentation on [local development](https://github.com/PermanentOrg/infrastructure/blob/main/README.md#local-development). All of those steps can be done from within your [devenv](https://github.com/PermanentOrg/devenv/) VM, so you don't need to install anything on your host. Hopefully, with this branch, you'll be able to figure out how to fill out the `.env` file! Please let me know if there is still anything confusing or non-obvious to you.