### PR TITLE
Add apple file for linking to Permanent on iOS

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -42,6 +42,7 @@ export AWS_REGION=us-east-1
 # Permanent environment name; must be one of [local, dev, staging, prod].
 # For developers, keep this as dev.
 export PERM_ENV=dev
+export APP_ID="TESTING.permanent.permanent.dev"
 
 # Sentry DSN for upload-service
 # Get this from Sentry: project > settings > "Client Keys (DSN)" > DSN.

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -23,16 +23,19 @@ jobs:
         machine: [backend, taskrunner, cron]
         environment:
           - perm_env: dev
+            app_id: "TEST.org.permanent.permanent.dev"
             aws_deploy_key: DEV_AWS_ACCESS_KEY_ID
             aws_deploy_secret: DEV_AWS_SECRET_ACCESS_KEY
             notification_database_url: DEV_NOTIFICATION_DATABASE_URL
             notification_firebase_credentials: DEV_NOTIFICATION_FIREBASE_CREDENTIALS
           - perm_env: staging
+            app_id: "C8YKZNBVWT.org.permanent.permanent.staging"
             aws_deploy_key: STAGING_AWS_ACCESS_KEY_ID
             aws_deploy_secret: STAGING_AWS_SECRET_ACCESS_KEY
             notification_database_url: STAGING_NOTIFICATION_DATABASE_URL
             notification_firebase_credentials: STAGING_NOTIFICATION_FIREBASE_CREDENTIALS
           - perm_env: prod
+            app_id: ""
             aws_deploy_key: PROD_AWS_ACCESS_KEY_ID
             aws_deploy_secret: PROD_AWS_SECRET_ACCESS_KEY
             notification_database_url: PROD_NOTIFICATION_DATABASE_URL
@@ -46,6 +49,7 @@ jobs:
           cd images
           packer build -var-file=${{ matrix.machine }}.json image.json
         env:
+          APP_ID: ${{ matrix.environment.app_id }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           DEPLOY_AWS_ACCESS_KEY_ID: ${{ secrets[matrix.environment.aws_deploy_key] }}

--- a/images/image.json
+++ b/images/image.json
@@ -50,6 +50,8 @@
       "extra_arguments": [
         "-vv",
         "--extra-vars",
+        "app_id={{user `app_id`}}",
+        "--extra-vars",
         "aws_access_key_id={{user `aws_key`}}",
         "--extra-vars",
         "aws_region={{user `aws_region`}}",
@@ -89,6 +91,7 @@
     }
   ],
   "variables": {
+    "app_id": "{{env `APP_ID`}}",
     "aws_key": "{{env `DEPLOY_AWS_ACCESS_KEY_ID`}}",
     "aws_region": "{{env `AWS_REGION`}}",
     "aws_secret": "{{env `DEPLOY_AWS_SECRET_ACCESS_KEY`}}",

--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -46,6 +46,13 @@ mkdir /var/www/.cache
 envsubst < $TEMPLATES_PATH/var/www/.aws/credentials > /var/www/.aws/credentials
 envsubst < $TEMPLATES_PATH/var/www/.aws/config > /var/www/.aws/config
 
+# This is needed for our iOS app to open links to Permanent in the app
+# https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html
+mkdir /var/www/html/.well-known
+envsubst \
+  < $TEMPLATES_PATH/var/www/html/.well-known/apple-app-site-association \
+  > /var/www/html/.well-known/apple-app-site-association
+
 # Make www-data the owner of /var/www/ because writing to this dir is required for file conversions
 chown -R www-data /var/www/
 

--- a/provisioners/setup.yml
+++ b/provisioners/setup.yml
@@ -82,6 +82,7 @@
     - name: Run the configure script
       script: "{{ script }}"
       environment:
+        APP_ID: "{{ app_id }}"
         AWS_REGION: "{{ aws_region }}"
         AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
         AWS_ACCESS_SECRET: "{{ aws_secret_access_key }}"

--- a/templates/etc/apache2/sites-enabled/dev.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/dev.permanent.conf
@@ -83,6 +83,7 @@
     Alias /app /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
+    Alias /.well-known /var/www/html/.well-known
     <Directory "/data/www/mdot/dist/mdot">
         Require all granted
         Options FollowSymLinks

--- a/templates/etc/apache2/sites-enabled/local.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/local.permanent.conf
@@ -70,6 +70,7 @@
     Alias /app /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
+    Alias /.well-known /var/www/html/.well-known
     <Directory "/data/www/mdot/dist/mdot">
         Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
         Header set Pragma "no-cache"

--- a/templates/etc/apache2/sites-enabled/prod.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/prod.permanent.conf
@@ -90,6 +90,7 @@
     Alias /app /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
+    Alias /.well-known /var/www/html/.well-known
     <Directory "/data/www/mdot/dist/mdot">
         Require all granted
         Options FollowSymLinks

--- a/templates/etc/apache2/sites-enabled/staging.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/staging.permanent.conf
@@ -84,6 +84,7 @@
     Alias /app /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
+    Alias /.well-known /var/www/html/.well-known
     <Directory "/data/www/mdot/dist/mdot">
         Require all granted
         Options FollowSymLinks

--- a/templates/var/www/html/.well-known/apple-app-site-association
+++ b/templates/var/www/html/.well-known/apple-app-site-association
@@ -1,0 +1,19 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "${APP_ID}",
+        "paths": [
+          "*"
+        ],
+        "components": [
+          {
+            "/": "*",
+            "comment": "Matches any URL"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
This adds a file outside of the password-protected area of our instance (so, a publicly available file) that contains information confirming that our iOS app can be used to open permanent.org links.

~It is WIP because the app_id is not being passed through correctly and so doesn't turn up in the apple file as expected.  Bummer!  I also only edited the staging conf file, for now, but we might want to change all of them in the same PR to reduce the number of image rebuilds.~

Resolves VSP-291.

## Steps to Test
I tested this by building an image, launching it in AWS, ssh-ing into it and looking to see whether `/var/www/.wellknown`  existed and had the expected contents.

`source .env && cd images && packer build -var-file=backend.json image.json`

