### PR TITLE
Pin to working version of community.general

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build image
         run: |
           ansible-galaxy install willshersystems.sshd
-          ansible-galaxy collection install community.general
+          ansible-galaxy collection install 'community.general:<3.3.0'
           cd images
           packer build -var-file=${{ matrix.machine }}.json image.json
         env:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,7 +28,7 @@ jobs:
       env:
         SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
     - name: Install ansible dependencies
-      run: ansible-galaxy collection install community.general
+      run: ansible-galaxy collection install 'community.general:<3.3.0'
     - name: Generate Inventory
       run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
     - name: Send start Slack notification

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -26,7 +26,7 @@ jobs:
       env:
         SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
     - name: Install ansible dependencies
-      run: ansible-galaxy collection install community.general
+      run: ansible-galaxy collection install 'community.general:<3.3.0'
     - name: Generate Inventory
       run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
     - name: Send start Slack notification

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,7 +26,7 @@ jobs:
       env:
         SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
     - name: Install ansible dependencies
-      run: ansible-galaxy collection install community.general
+      run: ansible-galaxy collection install 'community.general:<3.3.0'
     - name: Generate Inventory
       run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
     - name: Send start Slack notification


### PR DESCRIPTION
We use the [community.general plugin](https://docs.ansible.com/ansible/latest/collections/community/general/index.html) for the [npm module](https://docs.ansible.com/ansible/latest/collections/community/general/npm_module.html), to make it easier for us to install dependencies. Version 3.3.0 introduced a [bug](https://github.com/ansible-collections/community.general/issues/2917) with installing from a directory with a `package.json` file, which results in a stacktrace ending in:

```
KeyError: 'version'
```

Pin our dependency on the community.general plugin to before version 3.3.0 so that we can continue to deploy.

For reference: see also https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#installing-an-older-version-of-a-collection