### PR TITLE
Upgrade EC2 instance types

### DIFF
--- a/images/backend.json
+++ b/images/backend.json
@@ -2,6 +2,6 @@
   "configure_script": "configure.sh",
   "deploy_script": "deploy-backend.yml",
   "hostname": "{{env `PERM_ENV` }}",
-  "instance_type": "m4.large",
+  "instance_type": "m5.large",
   "volume_size": "1000"
 }

--- a/images/cron.json
+++ b/images/cron.json
@@ -2,6 +2,6 @@
   "configure_script": "configure-cron.sh",
   "deploy_script": "deploy-cron.yml",
   "hostname": "cron-{{env `PERM_ENV`}}",
-  "instance_type": "t2.micro",
+  "instance_type": "t3.micro",
   "volume_size": "100"
 }

--- a/images/taskrunner.json
+++ b/images/taskrunner.json
@@ -2,6 +2,6 @@
   "configure_script": "configure-taskrunner.sh",
   "deploy_script": "deploy-taskrunner.yml",
   "hostname": "taskrunner-{{env `PERM_ENV`}}",
-  "instance_type": "c4.xlarge",
+  "instance_type": "c5.xlarge",
   "volume_size": "1000"
 }

--- a/instances/dev/main.tf
+++ b/instances/dev/main.tf
@@ -45,7 +45,7 @@ resource "aws_instance" "api" {
 
 resource "aws_instance" "taskrunner" {
   ami                    = module.perm_env_data.taskrunner_ami
-  instance_type          = "c4.xlarge"
+  instance_type          = "c5.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet

--- a/instances/dev/main.tf
+++ b/instances/dev/main.tf
@@ -60,6 +60,9 @@ resource "aws_instance" "cron" {
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
+  credit_specification {
+    cpu_credits = "standard"
+  }
   tags = {
     Name = "${var.perm_env.name} cron"
   }

--- a/instances/dev/main.tf
+++ b/instances/dev/main.tf
@@ -56,7 +56,7 @@ resource "aws_instance" "taskrunner" {
 
 resource "aws_instance" "cron" {
   ami                    = module.perm_env_data.cron_ami
-  instance_type          = "t2.micro"
+  instance_type          = "t3.micro"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet

--- a/instances/dev/main.tf
+++ b/instances/dev/main.tf
@@ -33,7 +33,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m4.large"
+  instance_type          = "m5.large"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   private_ip             = "172.31.0.80"

--- a/instances/production/main.tf
+++ b/instances/production/main.tf
@@ -44,7 +44,7 @@ resource "aws_instance" "api" {
 
 resource "aws_instance" "taskrunner" {
   ami                    = module.perm_env_data.taskrunner_ami
-  instance_type          = "c4.xlarge"
+  instance_type          = "c5.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet

--- a/instances/production/main.tf
+++ b/instances/production/main.tf
@@ -55,7 +55,7 @@ resource "aws_instance" "taskrunner" {
 
 resource "aws_instance" "cron" {
   ami                    = module.perm_env_data.cron_ami
-  instance_type          = "t2.micro"
+  instance_type          = "t3.micro"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet

--- a/instances/production/main.tf
+++ b/instances/production/main.tf
@@ -59,6 +59,9 @@ resource "aws_instance" "cron" {
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
+  credit_specification {
+    cpu_credits = "standard"
+  }
   tags = {
     Name = "${var.perm_env.name} cron"
   }

--- a/instances/production/main.tf
+++ b/instances/production/main.tf
@@ -32,7 +32,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m4.large"
+  instance_type          = "m5.large"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet

--- a/instances/staging/main.tf
+++ b/instances/staging/main.tf
@@ -45,7 +45,7 @@ resource "aws_instance" "api" {
 
 resource "aws_instance" "taskrunner" {
   ami                    = module.perm_env_data.taskrunner_ami
-  instance_type          = "c4.xlarge"
+  instance_type          = "c5.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet

--- a/instances/staging/main.tf
+++ b/instances/staging/main.tf
@@ -33,7 +33,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m4.large"
+  instance_type          = "m5.large"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet

--- a/instances/staging/main.tf
+++ b/instances/staging/main.tf
@@ -60,6 +60,9 @@ resource "aws_instance" "cron" {
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
+  credit_specification {
+    cpu_credits = "standard"
+  }
   tags = {
     Name = "${var.perm_env.name} cron"
   }

--- a/instances/staging/main.tf
+++ b/instances/staging/main.tf
@@ -56,7 +56,7 @@ resource "aws_instance" "taskrunner" {
 
 resource "aws_instance" "cron" {
   ami                    = module.perm_env_data.cron_ami
-  instance_type          = "t2.micro"
+  instance_type          = "t3.micro"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet


### PR DESCRIPTION
In 2017, AWS introduced the current generation of instance types; as with previous generational changes, each corresponding instance type is strictly better: better performance, more resources, and less expensive.

Upgrade to the latest generation of instance types so that we can benefit from these improvements.

We're currently running one of each image (backend, cron, taskrunner) in each of our three environments (dev, staging, prod). In addition to the performance increases, these upgrades should save us about $900/year.

https://aws.amazon.com/ec2/instance-types/

[PER-8256 Upgrade AWS Instance Types](https://permanent.atlassian.net/browse/PER-8256)