### PR TITLE
Use new hard drive name

### DIFF
--- a/provisioners/setup.yml
+++ b/provisioners/setup.yml
@@ -46,11 +46,11 @@
     - name: Format filesystem on block device
       filesystem:
         fstype: ext4
-        dev: /dev/xvdb
+        dev: /dev/sdb
     - name: Mount block device to /data
       mount:
        path: /data
-       src: /dev/xvdb
+       src: /dev/sdb
        state: mounted
        fstype: ext4
 


### PR DESCRIPTION
It appears that the new generation of EC2 instance types - t3, c5, m5 - use a different naming scheme for additional attached EBS volumes. Previously, the second volume was named `/dev/xdvb`; now, it seems to be `/dev/sdb`. I haven't been able to find any documentation for this, but that's what the UI for manually launching an instance from the AWS console UI shows.

Update the name we're using to match.

PER-8256 Upgrade AWS Instance Types