### PR TITLE
Revert "Upgrade EC2 instance types"

### DIFF
--- a/images/backend.json
+++ b/images/backend.json
@@ -2,6 +2,6 @@
   "configure_script": "configure.sh",
   "deploy_script": "deploy-backend.yml",
   "hostname": "{{env `PERM_ENV` }}",
-  "instance_type": "m5.large",
+  "instance_type": "m4.large",
   "volume_size": "1000"
 }

--- a/images/cron.json
+++ b/images/cron.json
@@ -2,6 +2,6 @@
   "configure_script": "configure-cron.sh",
   "deploy_script": "deploy-cron.yml",
   "hostname": "cron-{{env `PERM_ENV`}}",
-  "instance_type": "t3.micro",
+  "instance_type": "t2.micro",
   "volume_size": "100"
 }

--- a/images/taskrunner.json
+++ b/images/taskrunner.json
@@ -2,6 +2,6 @@
   "configure_script": "configure-taskrunner.sh",
   "deploy_script": "deploy-taskrunner.yml",
   "hostname": "taskrunner-{{env `PERM_ENV`}}",
-  "instance_type": "c5.xlarge",
+  "instance_type": "c4.xlarge",
   "volume_size": "1000"
 }

--- a/instances/dev/main.tf
+++ b/instances/dev/main.tf
@@ -33,7 +33,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m5.large"
+  instance_type          = "m4.large"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   private_ip             = "172.31.0.80"
@@ -45,7 +45,7 @@ resource "aws_instance" "api" {
 
 resource "aws_instance" "taskrunner" {
   ami                    = module.perm_env_data.taskrunner_ami
-  instance_type          = "c5.xlarge"
+  instance_type          = "c4.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
@@ -56,13 +56,10 @@ resource "aws_instance" "taskrunner" {
 
 resource "aws_instance" "cron" {
   ami                    = module.perm_env_data.cron_ami
-  instance_type          = "t3.micro"
+  instance_type          = "t2.micro"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
-  credit_specification {
-    cpu_credits = "standard"
-  }
   tags = {
     Name = "${var.perm_env.name} cron"
   }

--- a/instances/production/main.tf
+++ b/instances/production/main.tf
@@ -32,7 +32,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m5.large"
+  instance_type          = "m4.large"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
@@ -44,7 +44,7 @@ resource "aws_instance" "api" {
 
 resource "aws_instance" "taskrunner" {
   ami                    = module.perm_env_data.taskrunner_ami
-  instance_type          = "c5.xlarge"
+  instance_type          = "c4.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
@@ -55,13 +55,10 @@ resource "aws_instance" "taskrunner" {
 
 resource "aws_instance" "cron" {
   ami                    = module.perm_env_data.cron_ami
-  instance_type          = "t3.micro"
+  instance_type          = "t2.micro"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
-  credit_specification {
-    cpu_credits = "standard"
-  }
   tags = {
     Name = "${var.perm_env.name} cron"
   }

--- a/instances/staging/main.tf
+++ b/instances/staging/main.tf
@@ -33,7 +33,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m5.large"
+  instance_type          = "m4.large"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
@@ -45,7 +45,7 @@ resource "aws_instance" "api" {
 
 resource "aws_instance" "taskrunner" {
   ami                    = module.perm_env_data.taskrunner_ami
-  instance_type          = "c5.xlarge"
+  instance_type          = "c4.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
@@ -56,13 +56,10 @@ resource "aws_instance" "taskrunner" {
 
 resource "aws_instance" "cron" {
   ami                    = module.perm_env_data.cron_ami
-  instance_type          = "t3.micro"
+  instance_type          = "t2.micro"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
-  credit_specification {
-    cpu_credits = "standard"
-  }
   tags = {
     Name = "${var.perm_env.name} cron"
   }


### PR DESCRIPTION
Reverts PermanentOrg/infrastructure#60

The new instance types use different device names for attached EBS volumes, and according to [Amazon EBS and NVMe on Linux instances ](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html) those names are not stable. The change in #60 made sense as a quick and easy upgrade, but the additional complexity revealed by trying that upgrade in dev makes this a poor use of our limited engineering time right now.

Go back to our old instance types. #60 wasn't deployed to staging or prod, so all that will need to be done after this is merged is rerun terraform in dev.