### PR TITLE
PER-8543: Change iOS app links and add webcredentials

### DIFF
--- a/templates/var/www/html/.well-known/apple-app-site-association
+++ b/templates/var/www/html/.well-known/apple-app-site-association
@@ -5,15 +5,18 @@
       {
         "appID": "${APP_ID}",
         "paths": [
-          "*"
+          "/share/*"
         ],
         "components": [
           {
-            "/": "*",
-            "comment": "Matches any URL"
+            "/": "/share/*",
+            "comment": "Matches share URLs"
           }
         ]
       }
     ]
+  },
+  "webcredentials": {
+    "apps": [ "${APP_ID}" ]
   }
 }


### PR DESCRIPTION
This PR changes the iOS app links to only trigger on share links since so far that's the only kind of URL the app can respond to. It also adds webcredentials to the same JSON file, so that saved logins can be shared between the app and website on iOS.
