### PR TITLE
Fixes PER-8409; run database migrations on deploy

### DIFF
--- a/provisioners/deploy-backend.yml
+++ b/provisioners/deploy-backend.yml
@@ -55,6 +55,11 @@
         recurse: yes
         owner: www-data
         group: deployer
+    - name: Run database migrations
+      command: "php migrate.php"
+      become_user: deployer
+      args:
+        chdir: /data/www/library
     - name: Create cronjobs
       copy:
         src: "/data/www/task-runner/scripts/{{ item }}"


### PR DESCRIPTION
Docs: https://docs.ansible.com/ansible/2.9/modules/command_module.html
Proof: https://github.com/PermanentOrg/infrastructure/runs/3932362140?check_suite_focus=true

```
TASK [Run database migrations] *************************************************
task path: /home/runner/work/infrastructure/infrastructure/provisioners/deploy-backend.yml:58
changed: [ec2-34-210-192-5.***.compute.amazonaws.com] => {"changed": true, "cmd": ["php", "migrate.php"], "delta": "0:00:00.107757", "end": "2021-10-18 21:59:31.777148", "msg": "", "rc": 0, "start": "2021-10-18 21:59:31.669391", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```