### PR TITLE
Pass HTTP Authorization header to API

### DIFF
--- a/templates/etc/apache2/sites-enabled/dev.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/dev.permanent.conf
@@ -66,6 +66,7 @@
 
     AliasMatch ^/api(.*) /data/www/api/index.php$1
     <Directory "/data/www/api">
+        CGIPassAuth On
         Require all granted
         RewriteEngine On
         RewriteCond %{DOCUMENT_ROOT}/maintenance.html -f

--- a/templates/etc/apache2/sites-enabled/local.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/local.permanent.conf
@@ -61,6 +61,7 @@
 
     AliasMatch ^/api(.*) /data/www/api/index.php$1
     <Directory "/data/www/api">
+        CGIPassAuth On
         Require all granted
     </Directory>
 

--- a/templates/etc/apache2/sites-enabled/prod.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/prod.permanent.conf
@@ -72,6 +72,7 @@
 
     AliasMatch ^/api(.*) /data/www/api/index.php$1
     <Directory "/data/www/api">
+        CGIPassAuth On
         Require all granted
         RewriteEngine On
         RewriteCond %{DOCUMENT_ROOT}/maintenance.html -f

--- a/templates/etc/apache2/sites-enabled/staging.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/staging.permanent.conf
@@ -66,6 +66,7 @@
 
     AliasMatch ^/api(.*) /data/www/api/index.php$1
     <Directory "/data/www/api">
+        CGIPassAuth On
         Require all granted
         RewriteEngine On
         RewriteCond %{DOCUMENT_ROOT}/maintenance.html -f


### PR DESCRIPTION
In order for the API to be able to accept OAuth tokens, Apache needs to pass along the [Authorization header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) clients will use. By default, it does not; from the [documentation on the CGIPassAuth directive](https://httpd.apache.org/docs/current/en/mod/core.html#cgipassauth):

> Normally these HTTP headers are hidden from scripts. This is to disallow scripts from seeing user ids and passwords used to access the server when HTTP Basic authentication is enabled in the web server.

The web server does not (and will not) use HTTP Basic authentication. (It may be of historical interest to note that it once did, in order to protect the dev/staging wordpress sites, but that was functionally disabled last spring and finally removed in PR #73.)

Turn on the CGIPassAuth directive in local, dev, staging, and production.

[PER-8523 Validate auth tokens on API requests](https://permanent.atlassian.net/browse/PER-8523)