### PR TITLE
Redirect the local root to the application

### DIFF
--- a/templates/etc/apache2/sites-enabled/local.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/local.permanent.conf
@@ -82,6 +82,8 @@
         RewriteRule ^(.*)$ index.html [L,QSA]
     </Directory>
 
+    RewriteRule ^/$ /app [last,redirect]
+
     ErrorLog "/var/log/permanent/error.log"
     CustomLog "/var/log/permanent/access.log" vhost_combined
 </VirtualHost>


### PR DESCRIPTION
Signing out of the application redirects the user to the root page of the domain. In dev, staging, and prod, our AWS load balancer configuration sends such requests off to Lightsail, the hosted Wordpress instance.

Since local no longer has a local Wordpress instance (see PR #73), and since no AWS load balancer is running locally, visiting `https://local.permament.org` results in a 403 Forbidden error, which is unhelpful and frustrating.

Instead, use an [Apache rewrite rule](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule) to return a redirect into the application, so that devs can waste less time and frustration.

PER-8215 Leave self-hosted Wordpress behind forever!