### PR TITLE
Run migrations during code deploys

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Send start Slack notification
       run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
     - name: Run deploy
-      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }}" -i inventory.ini
+      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=true" -i inventory.ini
       env:
         ANSIBLE_PIPELINING: True
         ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Send start Slack notification
       run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
     - name: Run deploy
-      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }}" -i inventory.ini
+      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=true" -i inventory.ini
       env:
         ANSIBLE_PIPELINING: True
         ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Send start Slack notification
       run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
     - name: Run deploy
-      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }}" -i inventory.ini
+      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=true" -i inventory.ini
       env:
         ANSIBLE_PIPELINING: True
         ANSIBLE_HOST_KEY_CHECKING: False

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Image creation can also be done manually on your local machine. The following ex
 
 ```
 cp .env.template .env # add your AWS access credentials
-source .env && cd images && packer build -var-file=cron.json image.json
+source .env
+cd images
+packer build -var-file=cron.json image.json
 ```
 
 For Permanent employees: use the AWS access keys associated with the `build` IAM user, not the keys associated with your personal AWS account.

--- a/provisioners/deploy-backend.yml
+++ b/provisioners/deploy-backend.yml
@@ -53,6 +53,12 @@
         recurse: yes
         owner: www-data
         group: deployer
+    - name: Run database migrations
+      when: "run_migrations is defined and (run_migrations | bool)"
+      command: "php migrate.php"
+      become_user: deployer
+      args:
+        chdir: /data/www/library
     - name: Create cronjobs
       copy:
         src: "/data/www/task-runner/scripts/{{ item }}"


### PR DESCRIPTION
Simplify the work of deployments by automatically running database migrations, rather than requiring an engineer to manually do so. This removes the risk of the code being ahead of the database structure long-term, reduces the window between code being deployed and the database looking as the code expects, and reduces deployment time overall.

We were briefly running database migrations automatically as part of deploying, but ran into a problem and turned automatic migrations off (in PR #84). The problem we encountered was that the image builder instance was not always on the same subnet as the production instance, and so sometime image building would fail because migrations could not be run. That shed light on a more important problem, though: we need to not run migrations during image creation! There can be a substantial delay between building an image and running terraform to bring up new instances based on that image, and during that time the database can be ahead of the code.

Instead, we need to run database migrations only during code deploys, and not during image creation. Do so by adding a new variable that we only set during the GitHub Actions workflows for code deployments, and not during the image building workflow. Use an [Ansible conditional](https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#conditionals-based-on-variables) to skip the migration task during image building.

PER-8780 Run database migrations on code deployment