### PR TITLE
Add path to deeplink to public files on mobile

### DIFF
--- a/templates/var/www/html/.well-known/apple-app-site-association
+++ b/templates/var/www/html/.well-known/apple-app-site-association
@@ -5,12 +5,17 @@
       {
         "appID": "${APP_ID}",
         "paths": [
-          "/share/*"
+          "/share/*",
+          "/p/*"
         ],
         "components": [
           {
             "/": "/share/*",
             "comment": "Matches share URLs"
+          },
+          {
+            "/": "/p/*",
+            "comment": "Matches public archive URLs"
           }
         ]
       }


### PR DESCRIPTION
As requested by @v-rusu, since we now want to be able to open public files in the apps.

Message at https://permanent-org.slack.com/archives/C01AK4233TN/p1649783513086679, ticket at https://permanent.atlassian.net/browse/VSP-572