### PR TITLE
Remove system exception check

### DIFF
--- a/provisioners/deploy-cron.yml
+++ b/provisioners/deploy-cron.yml
@@ -53,7 +53,6 @@
         - daily/account-engagement
         - daily/facebook-retrieve
         - daily/remove_deleted_records
-        - daily/system_exception_report
         - daily/zip_cleanup
         - daily/zoho_integration
         - weekly/file_upload_summary


### PR DESCRIPTION
We [removed the system exception check script from the back-end](https://github.com/PermanentOrg/back-end/pull/67). Also remove it from our deployment script.