### PR TITLE
Remove daily Facebook task

### DIFF
--- a/provisioners/deploy-cron.yml
+++ b/provisioners/deploy-cron.yml
@@ -51,7 +51,6 @@
         - hourly/cleanup-bad-uploads
         - hourly/system-check
         - daily/account-engagement
-        - daily/facebook-retrieve
         - daily/remove_deleted_records
         - daily/zip_cleanup
         - daily/zoho_integration


### PR DESCRIPTION
[The Facebook integration was suspended last year](https://www.permanent.org/blog/why-weve-chosen-to-suspend-our-facebook-integration/). The daily task was not finding any work to do, and never will. Stop deploying the cron job.

Once this is merged, devs will need to either rebuild their Vagrant VM, or delete the cron job locally:

```sh
sudo rm /etc/cron.daily/facebook-retrieve
```

Issue https://github.com/PermanentOrg/back-end/issues/135