### PR TITLE
Add bcmath for better money calculation

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -41,6 +41,7 @@ apt-get -qq install -y \
   mysql-client \
   newrelic-php5 \
   nodejs \
+  php-bcmath \
   php-cli \
   php-curl \
   php-gd \


### PR DESCRIPTION
We want to use https://www.php.net/manual/en/function.bcdiv.php for a
particular calculation in the new donations flow, to avoid issues with
float math.  To do that, we need to install the bcmath extension on
the back-end machines in each environment.

This would install it on your local environment, too, if you
reprovisioned.  However, it's easier/faster to just run `sudo apt-get
install php-bcmath` and then `sudo service apache2 restart`.