### PR TITLE
Deactivate cleanup-bad-uploads cron job

### DIFF
--- a/provisioners/deploy-cron.yml
+++ b/provisioners/deploy-cron.yml
@@ -48,7 +48,6 @@
       loop:
         - minute/disk-check
         - minute/notification-runner
-        - hourly/cleanup-bad-uploads
         - hourly/system-check
         - daily/account-engagement
         - daily/remove_deleted_records


### PR DESCRIPTION
This PR will turn off the cleanup-bad-uploads cron job, which is unused.

Evidence that the cleanup-bad-uploads job is unused:
1. The job operates on entries in the `sqs_task` table with `taskConstant = 'task.cleanup.bad.uploads'`. I have searched the `back-end` repo and found no path by which such an entry could be created.
2. I've been checking for entries in the `sqs_task` table with `taskConstant = 'task.cleanup.bad.uploads'` in the last 10 minutes of each hour (right before the cron job is triggered on the hour) during the work day since the afternoon of 6/7/22 and found no records on any occasion. I intend to continue doing this until PER-8260 is deployed.