### PR TITLE
Add `/gallery` path to web-app

### DIFF
--- a/templates/etc/apache2/sites-enabled/dev.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/dev.permanent.conf
@@ -81,6 +81,7 @@
     RewriteRule ^/m$ /app [L,R=302]
     RewriteRule ^/m/(.*)$ /app/$1 [L,R=302]
     Alias /app /data/www/mdot/dist/mdot
+    Alias /gallery /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     Alias /.well-known /var/www/html/.well-known

--- a/templates/etc/apache2/sites-enabled/local.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/local.permanent.conf
@@ -68,6 +68,7 @@
     RewriteRule ^/m$ /app [L,R=302]
     RewriteRule ^/m/(.*)$ /app/$1 [L,R=302]
     Alias /app /data/www/mdot/dist/mdot
+    Alias /gallery /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     Alias /.well-known /var/www/html/.well-known

--- a/templates/etc/apache2/sites-enabled/prod.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/prod.permanent.conf
@@ -88,6 +88,7 @@
     RewriteRule ^/m$ /app [L,R=302]
     RewriteRule ^/m/(.*)$ /app/$1 [L,R=302]
     Alias /app /data/www/mdot/dist/mdot
+    Alias /gallery /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     Alias /.well-known /var/www/html/.well-known

--- a/templates/etc/apache2/sites-enabled/staging.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/staging.permanent.conf
@@ -82,6 +82,7 @@
     RewriteRule ^/m$ /app [L,R=302]
     RewriteRule ^/m/(.*)$ /app/$1 [L,R=302]
     Alias /app /data/www/mdot/dist/mdot
+    Alias /gallery /data/www/mdot/dist/mdot
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     Alias /.well-known /var/www/html/.well-known


### PR DESCRIPTION
The public gallery landing page uses the new URL path `/gallery` which is currently not set up in Apache to redirect to the web-app. To make it accessible, add it to each environment's Apache configuration.