### PR TITLE
Disable MySQL migrations in dev

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Send start Slack notification
       run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
     - name: Run deploy
-      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=true" -i inventory.ini
+      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=false" -i inventory.ini
       env:
         ANSIBLE_PIPELINING: True
         ANSIBLE_HOST_KEY_CHECKING: False


### PR DESCRIPTION
We are switching our dev environment to use PostgreSQL instead of MySQL,
so we no longer want to run MySQL migrations on dev deploys.