### PR TITLE
Add static IPs to SFTP deployments

### DIFF
--- a/instances/dev/main.tf
+++ b/instances/dev/main.tf
@@ -73,6 +73,7 @@ resource "aws_instance" "sftp" {
   instance_type          = "c4.large"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
+  private_ip             = "172.31.8.191"
   subnet_id              = module.perm_env_data.subnet
   tags = {
     Name = "${var.perm_env.name} sftp"

--- a/instances/production/main.tf
+++ b/instances/production/main.tf
@@ -74,6 +74,7 @@ resource "aws_instance" "sftp" {
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
+  private_ip             = "172.31.43.141"
   tags = {
     Name = "${var.perm_env.name} sftp"
     type = "${var.perm_env.name} sftp"

--- a/instances/staging/main.tf
+++ b/instances/staging/main.tf
@@ -74,6 +74,7 @@ resource "aws_instance" "sftp" {
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet
+  private_ip             = "172.31.31.248"
   tags = {
     Name = "${var.perm_env.name} sftp"
     type = "${var.perm_env.name} sftp"


### PR DESCRIPTION
We use a few AWS tools to map a url to a given backend service:

1. Target groups which let us specify which EC2 private IP addresses are running copies of a given piece of code
2. Load balancers which map traffic to target groups based on whatever balancer rules are configured.
3. Route 53 (DNS) which map URLs to load balancers

In order to do that first step our SFTP services all need static IPs that the target groups can point to.

These IP addresses are just the ones that AWS had assigned the
non-static deployments; there's nothing particularly special about them
(though they have been hard coded into our target groups.)

Related to Issue #108