### PR TITLE
Per 9075 dbmate migrations

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,9 +1,9 @@
 name: Dev code deploy
 
 on:
-    workflow_dispatch:
-    schedule:
-    - cron:  '0 6 * * *'
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
 
 jobs:
   deploy:
@@ -14,35 +14,35 @@ jobs:
         machine: [backend, cron, taskrunner, sftp]
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-    - name: Save ssh deploy key to a file
-      run: |
-        echo "$SSH_KEY" > key
-        chmod 400 key
-      env:
-        SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
-    - name: Install ansible dependencies
-      run: ansible-galaxy collection install 'community.general:<3.3.0'
-    - name: Generate Inventory
-      run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
-    - name: Send start Slack notification
-      run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
-    - name: Run deploy
-      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=true" -i inventory.ini
-      env:
-        ANSIBLE_PIPELINING: True
-        ANSIBLE_HOST_KEY_CHECKING: False
-    - name: Send end Slack notification
-      run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy complete"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
+      - uses: actions/checkout@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Save ssh deploy key to a file
+        run: |
+          echo "$SSH_KEY" > key
+          chmod 400 key
+        env:
+          SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+      - name: Install ansible dependencies
+        run: ansible-galaxy collection install 'community.general:<3.3.0'
+      - name: Generate Inventory
+        run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
+      - name: Send start Slack notification
+        run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
+      - name: Run deploy
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=true" -i inventory.ini
+        env:
+          ANSIBLE_PIPELINING: True
+          ANSIBLE_HOST_KEY_CHECKING: False
+      - name: Send end Slack notification
+        run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy complete"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
   test_deploy:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
-    - name: Trigger the functional test
-      run: curl -X POST -H 'Accept:application/vnd.github.v3+json' -H 'Authorization:Bearer ${{ secrets.CKRUM_PAT }}' https://api.github.com/repos/PermanentOrg/functional-test/dispatches -d '{"event_type":"dev_deployed"}'
+      - name: Trigger the functional test
+        run: curl -X POST -H 'Accept:application/vnd.github.v3+json' -H 'Authorization:Bearer ${{ secrets.CKRUM_PAT }}' https://api.github.com/repos/PermanentOrg/functional-test/dispatches -d '{"event_type":"dev_deployed"}'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=true" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.DEV_DATABASE_URL }} run_migrations=true" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Send start Slack notification
       run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
     - name: Run deploy
-      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=false" -i inventory.ini
+      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=true" -i inventory.ini
       env:
         ANSIBLE_PIPELINING: True
         ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,7 +1,7 @@
 name: Prod code deploy
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -12,35 +12,35 @@ jobs:
         machine: [backend, cron, taskrunner, sftp]
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-    - name: Save ssh deploy key to a file
-      run: |
-        echo "$SSH_KEY" > key
-        chmod 400 key
-      env:
-        SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
-    - name: Install ansible dependencies
-      run: ansible-galaxy collection install 'community.general:<3.3.0'
-    - name: Generate Inventory
-      run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
-    - name: Send start Slack notification
-      run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
-    - name: Run deploy
-      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=false" -i inventory.ini
-      env:
-        ANSIBLE_PIPELINING: True
-        ANSIBLE_HOST_KEY_CHECKING: False
-    - name: Send end Slack notification
-      run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy complete"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
+      - uses: actions/checkout@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Save ssh deploy key to a file
+        run: |
+          echo "$SSH_KEY" > key
+          chmod 400 key
+        env:
+          SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+      - name: Install ansible dependencies
+        run: ansible-galaxy collection install 'community.general:<3.3.0'
+      - name: Generate Inventory
+        run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
+      - name: Send start Slack notification
+        run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
+      - name: Run deploy
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=false" -i inventory.ini
+        env:
+          ANSIBLE_PIPELINING: True
+          ANSIBLE_HOST_KEY_CHECKING: False
+      - name: Send end Slack notification
+        run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy complete"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
   test_deploy:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
-    - name: Trigger the functional test
-      run: curl -X POST -H 'Accept:application/vnd.github.v3+json' -H 'Authorization:Bearer ${{ secrets.CKRUM_PAT }}' https://api.github.com/repos/PermanentOrg/functional-test/dispatches -d '{"event_type":"prod_deployed"}'
+      - name: Trigger the functional test
+        run: curl -X POST -H 'Accept:application/vnd.github.v3+json' -H 'Authorization:Bearer ${{ secrets.CKRUM_PAT }}' https://api.github.com/repos/PermanentOrg/functional-test/dispatches -d '{"event_type":"prod_deployed"}'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=false" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.PROD_DATABASE_URL }} run_migrations=true" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=false" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.STAGING_DATABASE_URL }} run_migrations=true" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,7 +1,7 @@
 name: Staging code deploy
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -12,35 +12,35 @@ jobs:
         machine: [backend, cron, taskrunner, sftp]
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-    - name: Save ssh deploy key to a file
-      run: |
-        echo "$SSH_KEY" > key
-        chmod 400 key
-      env:
-        SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
-    - name: Install ansible dependencies
-      run: ansible-galaxy collection install 'community.general:<3.3.0'
-    - name: Generate Inventory
-      run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
-    - name: Send start Slack notification
-      run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
-    - name: Run deploy
-      run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=false" -i inventory.ini
-      env:
-        ANSIBLE_PIPELINING: True
-        ANSIBLE_HOST_KEY_CHECKING: False
-    - name: Send end Slack notification
-      run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy complete"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
+      - uses: actions/checkout@v1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Save ssh deploy key to a file
+        run: |
+          echo "$SSH_KEY" > key
+          chmod 400 key
+        env:
+          SSH_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+      - name: Install ansible dependencies
+        run: ansible-galaxy collection install 'community.general:<3.3.0'
+      - name: Generate Inventory
+        run: ./scripts/generate_inventory.sh ${{ env.perm_env }} ${{ matrix.machine }}
+      - name: Send start Slack notification
+        run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
+      - name: Run deploy
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} run_migrations=false" -i inventory.ini
+        env:
+          ANSIBLE_PIPELINING: True
+          ANSIBLE_HOST_KEY_CHECKING: False
+      - name: Send end Slack notification
+        run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy complete"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
   test_deploy:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
-    - name: Trigger the functional test
-      run: curl -X POST -H 'Accept:application/vnd.github.v3+json' -H 'Authorization:Bearer ${{ secrets.CKRUM_PAT }}' https://api.github.com/repos/PermanentOrg/functional-test/dispatches -d '{"event_type":"staging_deployed"}'
+      - name: Trigger the functional test
+        run: curl -X POST -H 'Accept:application/vnd.github.v3+json' -H 'Authorization:Bearer ${{ secrets.CKRUM_PAT }}' https://api.github.com/repos/PermanentOrg/functional-test/dispatches -d '{"event_type":"staging_deployed"}'

--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -71,6 +71,11 @@ then
    update-alternatives --quiet --install /usr/bin/nodejs nodejs /usr/bin/node 50 --slave /usr/share/man/man1/nodejs.1.gz nodejs.1.gz /usr/share/man/man1/node.1.gz
 fi
 
+# Install dbmate directly, since it isn't packaged
+echo "Install dbmate"
+curl -L -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-amd64
+sudo chmod +x /usr/local/bin/dbmate
+
 echo "Configure apache"
 
 # This is the Apache DocumentRoot, and where the aws php sdk will look for credentials

--- a/provisioners/deploy-backend.yml
+++ b/provisioners/deploy-backend.yml
@@ -55,7 +55,7 @@
         group: deployer
     - name: Run database migrations
       when: "run_migrations is defined and (run_migrations | bool)"
-      command: "dbmate up"
+      command: "dbmate --url {{ database_url }} up"
       become_user: deployer
       args:
         chdir: /data/www/library

--- a/provisioners/deploy-backend.yml
+++ b/provisioners/deploy-backend.yml
@@ -55,7 +55,7 @@
         group: deployer
     - name: Run database migrations
       when: "run_migrations is defined and (run_migrations | bool)"
-      command: "php migrate.php"
+      command: "dbmate up"
       become_user: deployer
       args:
         chdir: /data/www/library

--- a/provisioners/deploy-backend.yml
+++ b/provisioners/deploy-backend.yml
@@ -7,7 +7,7 @@
       file:
         path: /etc/cron.minute
         state: directory
-        mode: '0755'
+        mode: "0755"
     - name: Add minute crontab
       cron:
         cron_file: minutely
@@ -27,9 +27,9 @@
         - notification-service
     - name: Untar packages
       unarchive:
-         src: "/data/tmp/{{ item }}.tar.gz"
-         dest: /data/www/
-         remote_src: yes
+        src: "/data/tmp/{{ item }}.tar.gz"
+        dest: /data/www/
+        remote_src: yes
       loop:
         - api
         - daemon

--- a/provisioners/deploy-backend.yml
+++ b/provisioners/deploy-backend.yml
@@ -53,6 +53,12 @@
         recurse: yes
         owner: www-data
         group: deployer
+    - name: Install dbmate
+      when: "run_migrations is defined and (run_migrations | bool)"
+      command: "curl -L -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-amd64"
+    - name: Make dbmate executable
+      when: "run_migrations is defined and (run_migrations | bool)"
+      command: "sudo chmod +x /usr/local/bin/dbmate"
     - name: Run database migrations
       when: "run_migrations is defined and (run_migrations | bool)"
       command: "dbmate --url {{ database_url }} up"


### PR DESCRIPTION
This change, along with a corresponding change in the `devenv` repo, will make it possible for us to run migrations against PostgreSQL locally and in our deployed environments. 

Notes:
- I don't like installing via `sudo curl`, especially with `-L`, since we could be installing and making *anything* executable, if the `dbmate` maintainers aren't trustworthy. I don't see a better _recommended_ way, since `dbmate` isn't packaged, but we could potentially upload our own tarball to S3 and install from there. What do you think?
- I pinned us to the current release of `dbmate` to avoid confusing problems from using `latest`
- I only turned on migrations in dev for this PR (we turned them off in all the environments when we did the switchover). Should I just turn them on everywhere at once, do you think?