### PR TITLE
WIP: Add instruction to copy ssl files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+
+# Ignore ssl certs
+templates/etc/ssl

--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -92,6 +92,7 @@ chown -R www-data /var/www/
 service apache2 stop
 a2dissite 000-default
 cp $TEMPLATES_PATH/etc/apache2/apache2.conf /etc/apache2/apache2.conf
+cp $TEMPLATES_PATH/etc/ssl/* /etc/ssl
 envsubst < $TEMPLATES_PATH/etc/apache2/sites-enabled/$PERM_SUBDOMAIN.permanent.conf > /etc/apache2/sites-enabled/$PERM_SUBDOMAIN.permanent.conf
 envsubst < $TEMPLATES_PATH/etc/apache2/sites-enabled/preload.permanent.conf > /etc/apache2/sites-enabled/preload.permanent.conf
 a2enmod expires


### PR DESCRIPTION
Apache fails to start each time we do a vagrant up with the complain that `permanent.key` was not found in /etc/ssl

This addeds a step to copy the ssl files from the template directory.

Discussion
_An instruction to download the ssl files in the specified directory is neccesary but there's a question of where?_