### PR TITLE
Install node 16 on backend machine

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -40,7 +40,6 @@ apt-get -qq install -y \
   mediainfo \
   mysql-client \
   newrelic-php5 \
-  nodejs \
   php-bcmath \
   php-cli \
   php-curl \
@@ -61,15 +60,15 @@ apt-get -qq install -y \
   wkhtmltopdf \
   zip
 
+echo "Install NodeJs"
+# The way to pin to a specific version of node is to load directly
+# See https://github.com/nodesource/distributions/issues/33#issuecomment-169345680
+curl -o nodejs.deb https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_16.17.1-deb-1nodesource1_amd64.deb
+apt -y install ./nodejs.deb
+rm ./nodejs.deb
+
 echo "Configure ImageMagick"
 cp $TEMPLATES_PATH/etc/ImageMagick-6/policy.xml /etc/ImageMagick-6/policy.xml
-
-# Make sure nodejs exists
-if ! [[ -f /usr/bin/nodejs ]]
-then
-   # It does not exist, so create it
-   update-alternatives --quiet --install /usr/bin/nodejs nodejs /usr/bin/node 50 --slave /usr/share/man/man1/nodejs.1.gz nodejs.1.gz /usr/share/man/man1/node.1.gz
-fi
 
 echo "Configure apache"
 

--- a/templates/etc/systemd/system/notification.service
+++ b/templates/etc/systemd/system/notification.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/data/www/notification-service
-ExecStart=/usr/bin/nodejs /data/www/notification-service/lib/index.js
+ExecStart=node /data/www/notification-service/lib/index.js
 KillMode=process
 Restart=always
 User=www-data

--- a/templates/etc/systemd/system/upload.service
+++ b/templates/etc/systemd/system/upload.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/data/www/upload-service
-ExecStart=/usr/bin/nodejs /data/www/upload-service/lib/index.js
+ExecStart=node /data/www/upload-service/lib/index.js
 KillMode=process
 Restart=always
 User=www-data


### PR DESCRIPTION
- Installs node 16 for backend machine
- Uses pattern seen in earlier
[commit](c4d2d758e9a0337d11949a1d36dc87d76e024399)
to pin to node 16, an
alternative could be to use `nvm`
- Just use node instead for creating and an alternative `nodejs`
and using it everywhere.


#113 