### PR TITLE
Turn off migrations in deployed environments

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.DEV_DATABASE_URL }} run_migrations=true" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.DEV_DATABASE_URL }} run_migrations=false" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.PROD_DATABASE_URL }} run_migrations=true" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.PROD_DATABASE_URL }} run_migrations=false" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.STAGING_DATABASE_URL }} run_migrations=true" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.STAGING_DATABASE_URL }} run_migrations=false" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False


### PR DESCRIPTION
We don't have any migrations to run in the back-end repo yet. Trying to run migrations without any existing is causing deployment to fail. Turn off migrations in all deployed environments for now, until we have one that needs to be run.