### PR TITLE
Bump Debian Buster AMI version

### DIFF
--- a/images/backend.json
+++ b/images/backend.json
@@ -4,5 +4,5 @@
   "hostname": "{{env `PERM_ENV` }}",
   "instance_type": "m4.large",
   "volume_size": "1000",
-  "image_name": "debian-10-amd64-20201214-484"
+  "image_name": "debian-10-amd64-20220911-1135"
 }

--- a/images/cron.json
+++ b/images/cron.json
@@ -4,5 +4,5 @@
   "hostname": "cron-{{env `PERM_ENV`}}",
   "instance_type": "t2.micro",
   "volume_size": "100",
-  "image_name": "debian-10-amd64-20201214-484"
+  "image_name": "debian-10-amd64-20220911-1135"
 }

--- a/images/taskrunner.json
+++ b/images/taskrunner.json
@@ -4,5 +4,5 @@
   "hostname": "taskrunner-{{env `PERM_ENV`}}",
   "instance_type": "c4.xlarge",
   "volume_size": "1000",
-  "image_name": "debian-10-amd64-20201214-484"
+  "image_name": "debian-10-amd64-20220911-1135"
 }


### PR DESCRIPTION
The Debian Buster AMI we were using to build images has been deprecated. Update to the newest Debian Buster AMI so that the Build Images action works again.

See the [successful image build action](https://github.com/PermanentOrg/infrastructure/actions/runs/4105330902) run from this branch compared to the previously [failed image build](https://github.com/PermanentOrg/infrastructure/actions/runs/3962146617).

Resolves PER-9129: Adjust build images action to run correctly