### PR TITLE
Activate database migrations

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.DEV_DATABASE_URL }} run_migrations=false" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.DEV_DATABASE_URL }} run_migrations=true" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.PROD_DATABASE_URL }} run_migrations=false" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.PROD_DATABASE_URL }} run_migrations=true" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Send start Slack notification
         run: curl -X POST -H 'Content-type:application/json' --data '{"text":"${{ env.perm_env }} ${{ matrix.machine }} deploy started"}' https://hooks.slack.com/services/TBBFM3TEY/BJKUMT4CC/${{ secrets.SLACK_KEY }}
       - name: Run deploy
-        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.STAGING_DATABASE_URL }} run_migrations=false" -i inventory.ini
+        run: ansible-playbook provisioners/deploy-${{ matrix.machine }}.yml -vv -e "perm_env=${{ env.perm_env }} database_url=${{ secrets.STAGING_DATABASE_URL }} run_migrations=true" -i inventory.ini
         env:
           ANSIBLE_PIPELINING: True
           ANSIBLE_HOST_KEY_CHECKING: False


### PR DESCRIPTION
Currently, we have database migrations deactivated because attempting to run them when there are none causes a failure. Now, however, there is a migration in `back-end`, so running migrations should work.