### PR TITLE
PER-9158: Deeplink to reset password and signup

### DIFF
--- a/templates/var/www/html/.well-known/apple-app-site-association
+++ b/templates/var/www/html/.well-known/apple-app-site-association
@@ -21,6 +21,14 @@
           {
             "/": "/app/pr/manage",
             "comment": "Matches archive invite URLs"
+          },
+          {
+            "/": "/app/fa-reset/*",
+            "comment": "Matches forgot password URLs"
+          },
+          {
+            "/": "/app/auth/signup",
+            "comment": "Matches signup URL"
           }
         ]
       }


### PR DESCRIPTION
Add well known links for resetting forgotten passwords and signing up to Permanent. Note if the reset password link location changes in https://github.com/PermanentOrg/web-app/pull/192/files then it will need to change here to match.

I'm not sure if /* is necessary or if the default is to match on substrings. The reset password links will have some key strings at the end to indicate the request and the FusionAuth tenant. Signup urls could end with "signup" or could have a querystring on the end.