### PR TITLE
Update node to version 14.18.3 on backend instance

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -71,6 +71,10 @@ then
    update-alternatives --quiet --install /usr/bin/nodejs nodejs /usr/bin/node 50 --slave /usr/share/man/man1/nodejs.1.gz nodejs.1.gz /usr/share/man/man1/node.1.gz
 fi
 
+# Update nodejs to version 14
+npm install -g n
+n 14.18.3
+
 # Install dbmate directly, since it isn't packaged
 echo "Install dbmate"
 curl -L -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.16.0/dbmate-linux-amd64

--- a/templates/etc/systemd/system/notification.service
+++ b/templates/etc/systemd/system/notification.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/data/www/notification-service
-ExecStart=/usr/bin/nodejs /data/www/notification-service/lib/index.js
+ExecStart=node /data/www/notification-service/lib/index.js
 KillMode=process
 Restart=always
 User=www-data


### PR DESCRIPTION
Recent security-related updates to notification-service have caused notification-service to have dependencies that won't run on node 12, but require at least node 14. Conveniently, we've been testing our node projects against node 14 (in addition to 12) for some time, so it should be safe to upgrade.