### PR TITLE
Set MaxRequestWorkers to 256 in mpm_prefork.conf

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -97,6 +97,7 @@ chown -R www-data /var/www/
 service apache2 stop
 a2dissite 000-default
 cp $TEMPLATES_PATH/etc/apache2/apache2.conf /etc/apache2/apache2.conf
+cp $TEMPLATES_PATH/etc/apache2/mods-enabled/mpm_prefork.conf /etc/apache2/mods-enabled/mpm_prefork.conf
 envsubst < $TEMPLATES_PATH/etc/apache2/sites-enabled/$PERM_SUBDOMAIN.permanent.conf > /etc/apache2/sites-enabled/$PERM_SUBDOMAIN.permanent.conf
 envsubst < $TEMPLATES_PATH/etc/apache2/sites-enabled/preload.permanent.conf > /etc/apache2/sites-enabled/preload.permanent.conf
 a2enmod expires

--- a/templates/etc/apache2/mods-enabled/mpm_prefork.conf
+++ b/templates/etc/apache2/mods-enabled/mpm_prefork.conf
@@ -1,0 +1,16 @@
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# MaxRequestWorkers: maximum number of server processes allowed to start
+# MaxConnectionsPerChild: maximum number of requests a server process serves
+
+<IfModule mpm_prefork_module>
+	StartServers			 5
+	MinSpareServers		  5
+	MaxSpareServers		 10
+	MaxRequestWorkers	  256
+	MaxConnectionsPerChild   0
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Recently we experienced a series of crashes on prod caused by our API server exceeding its MaxRequestWorkers limit, which was set to 150. Setting it to the default value of 256 seems to have fixed the crashes, so this commit ensures we keep using that new value in future deploys