### PR TITLE
Update SFTP temporary storage

### DIFF
--- a/images/sftp.json
+++ b/images/sftp.json
@@ -3,6 +3,6 @@
   "deploy_script": "deploy-sftp.yml",
   "hostname": "sftp-{{env `PERM_ENV`}}",
   "instance_type": "m4.large",
-  "volume_size": "100",
+  "volume_size": "1000",
   "image_name": "debian-11-amd64-20220911-1135"
 }

--- a/templates/etc/permanent/sftp-service.env
+++ b/templates/etc/permanent/sftp-service.env
@@ -27,3 +27,6 @@ PERMANENT_API_BASE_PATH=https://${SERVER_DOMAIN}/api
 # See https://fusionauth.io/docs/v1/tech/apis/api-keys
 FUSION_AUTH_HOST=${FUSION_AUTH_HOST}
 FUSION_AUTH_KEY=${FUSION_AUTH_KEY_SFTP}
+
+# Override the default temporary directory to use attached space
+TMPDIR=/data/tmp


### PR DESCRIPTION
This PR mitigates the risk of the SFTP service having its temporary storage filled up in two ways:

1. It uses the `/data` disk (which is much larger) for temporary storage
2. It expands the size of `/data` from 100GB to 1000GB

I *believe* this is EBS storage, and if I'm reading the table correctly it costs $1.00 for every 10GB of provisioned storage (which means this portion of the PR would represent around $90 per month) https://aws.amazon.com/ebs/pricing/