### PR TITLE
Use the updated version of node to run upload-service

### DIFF
--- a/templates/etc/systemd/system/upload.service
+++ b/templates/etc/systemd/system/upload.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/data/www/upload-service
-ExecStart=/usr/bin/nodejs /data/www/upload-service/lib/index.js
+ExecStart=node /data/www/upload-service/lib/index.js
 KillMode=process
 Restart=always
 User=www-data


### PR DESCRIPTION
When we install our desired version of `node` on the backend instance, it can be invoked with the command: `node`. Currently, `upload-service` is started with `/usr/bin/nodejs`, which is not necessarily our desired version. This commit updates the `upload-service` template to use `node` instead, so it will run on the desired node version.