### PR TITLE
PER-9263: Basic web-app routing for WJMA

### DIFF
--- a/templates/etc/apache2/sites-enabled/dev.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/dev.permanent.conf
@@ -85,6 +85,7 @@
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     Alias /.well-known /var/www/html/.well-known
+    Alias /wjma /data/www/mdot/dist/mdot
     <Directory "/data/www/mdot/dist/mdot">
         Require all granted
         Options FollowSymLinks

--- a/templates/etc/apache2/sites-enabled/local.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/local.permanent.conf
@@ -72,6 +72,7 @@
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     Alias /.well-known /var/www/html/.well-known
+    Alias /wjma /data/www/mdot/dist/mdot
     <Directory "/data/www/mdot/dist/mdot">
         Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
         Header set Pragma "no-cache"

--- a/templates/etc/apache2/sites-enabled/prod.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/prod.permanent.conf
@@ -92,6 +92,7 @@
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     Alias /.well-known /var/www/html/.well-known
+    Alias /wjma /data/www/mdot/dist/mdot
     <Directory "/data/www/mdot/dist/mdot">
         Require all granted
         Options FollowSymLinks

--- a/templates/etc/apache2/sites-enabled/staging.permanent.conf
+++ b/templates/etc/apache2/sites-enabled/staging.permanent.conf
@@ -86,6 +86,7 @@
     Alias /p /data/www/mdot/dist/mdot
     Alias /share /data/www/mdot/dist/mdot
     Alias /.well-known /var/www/html/.well-known
+    Alias /wjma /data/www/mdot/dist/mdot
     <Directory "/data/www/mdot/dist/mdot">
         Require all granted
         Options FollowSymLinks


### PR DESCRIPTION
Redirecting a specific page to the webapp as we've done elsewhere. This is a partial step. We've discussed handling the entire redirection in this file, rather than also having a redirect line in the Angular routing.

Also interested in whether reviewers think it makes sense to have this across all configuration files, for consistency, or only on prod since that's the only place where the redirection will be useful (in other environments it'll most likely reach a page that says the archive doesn't exist).