### PR TITLE
Use /data for temporary storage in sftp service

### DIFF
--- a/templates/etc/permanent/sftp-service.env
+++ b/templates/etc/permanent/sftp-service.env
@@ -27,3 +27,6 @@ PERMANENT_API_BASE_PATH=https://${SERVER_DOMAIN}/api
 # See https://fusionauth.io/docs/v1/tech/apis/api-keys
 FUSION_AUTH_HOST=${FUSION_AUTH_HOST}
 FUSION_AUTH_KEY=${FUSION_AUTH_KEY_SFTP}
+
+# Override the default temporary directory to use attached space
+TMPDIR=/data/tmp


### PR DESCRIPTION
The sftp service will store temporary data as uploads are performed. The default tmp storage directory is `/tmp`, but we want to use the attached (and much larger) `/data` disk instead.