### PR TITLE
Increase sftp storage to 1TB

### DIFF
--- a/images/sftp.json
+++ b/images/sftp.json
@@ -3,6 +3,6 @@
   "deploy_script": "deploy-sftp.yml",
   "hostname": "sftp-{{env `PERM_ENV`}}",
   "instance_type": "m4.large",
-  "volume_size": "100",
+  "volume_size": "1000",
   "image_name": "debian-11-amd64-20220911-1135"
 }


### PR DESCRIPTION
In the short term we would like to mitigate the risk of the sftp service getting filled up by temporary files.  1TB doesn't prevent the risk entirely, but it does make it harder for the drive to get filled by a single user uploading a whole lot of content at once.