### PR TITLE
Add service to clean dead files

### DIFF
--- a/provisioners/configure-sftp.sh
+++ b/provisioners/configure-sftp.sh
@@ -60,9 +60,12 @@ sudo service nginx start
 
 echo "Configure SFTP Service"
 cp $TEMPLATES_PATH/etc/systemd/system/sftp.service /etc/systemd/system/sftp.service
+cp $TEMPLATES_PATH/etc/systemd/system/sftp-storage-cleanup.service /etc/systemd/system/sftp-storage-cleanup.service
+cp $TEMPLATES_PATH/etc/systemd/system/sftp-storage-cleanup.timer /etc/systemd/system/sftp-storage-cleanup.timer
 mkdir /etc/permanent/
 envsubst < $TEMPLATES_PATH/etc/permanent/sftp-service.env > /etc/permanent/sftp-service.env
 systemctl enable sftp.service
+systemctl enable sftp-storage-cleanup.timer
 
 # Set up generic deploy directories
 mkdir /var/www/.aws

--- a/provisioners/deploy-sftp.yml
+++ b/provisioners/deploy-sftp.yml
@@ -41,6 +41,7 @@
         state: stopped
       loop:
         - sftp.service
+        - sftp-storage-cleanup.timer
     - name: Start all services
       service:
         name: "{{ item }}"
@@ -48,6 +49,7 @@
         state: started
       loop:
         - sftp.service
+        - sftp-storage-cleanup.timer
     - name: Restart nginx
       service:
         name: nginx

--- a/templates/etc/systemd/system/sftp-storage-cleanup.service
+++ b/templates/etc/systemd/system/sftp-storage-cleanup.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Clear SFTP's temporary storage
+Wants=sftp-storage-cleanup.timer
+
+[Service]
+ExecStart=/usr/bin/find ${TMPDIR} -type f -mtime +5 -delete
+EnvironmentFile=/etc/permanent/sftp-service.env

--- a/templates/etc/systemd/system/sftp-storage-cleanup.timer
+++ b/templates/etc/systemd/system/sftp-storage-cleanup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Regularly cleans out the temporary storage used by the sftp service
+Requires=sftp-storage-cleanup.service
+
+[Timer]
+Unit=sftp-storage-cleanup.service
+OnCalendar=Daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This PR regularly cleans up the temporary storage directory for the sftp service.  Note that this will clean ANY old file in the temporary storage directory, since the sftp service does not currently populate a subdirectory.

We should consider modifying the sftp service, and this PR, to be more specific and use some type of `/data/tmp/sftp/` subdirectory.