### PR TITLE
Formally set log level to debug

### DIFF
--- a/templates/etc/permanent/sftp-service.env
+++ b/templates/etc/permanent/sftp-service.env
@@ -8,6 +8,11 @@ SENTRY_DSN=${SENTRY_DSN}
 # e.g. localhost
 SENTRY_ENVIRONMENT=${PERM_ENV}
 
+# The npm log level that you want the logger to emit.
+# See: https://github.com/winstonjs/winston#logging-levels
+# e.g. error, warn, info, http, verbose, debug, silly
+LOG_LEVEL=debug
+
 # The port the SSH service will listen on
 # See https://nodejs.org/api/net.html#serverlistenoptions-callback
 SSH_PORT=8022


### PR DESCRIPTION
As discussed, set the log level to debug for now. We may, however, want to bypass this by setting the `NODE_ENV` instead.