### PR TITLE
Update node installation + SFTP node version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/provisioners/configure-sftp.sh
+++ b/provisioners/configure-sftp.sh
@@ -15,23 +15,22 @@ echo $PERM_ENV  > /data/www/host.txt
 
 echo "Add custom sources"
 cp $TEMPLATES_PATH/usr/share/keyrings/*.asc /usr/share/keyrings/
-cp $TEMPLATES_PATH/etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/
+
+# Set up the correct node source
+export NODE_VERSION=18
+envsubst \
+  < $TEMPLATES_PATH/etc/apt/sources.list.d/nodesource.sources \
+  > /etc/apt/sources.list.d/nodesource.sources
 
 echo "Install packages"
 apt -qq update
 apt -qq install -y \
   curl \
-  wget \
   nginx \
-	nginx-extras \
-	unzip
-
-echo "Install NodeJs"
-# The way to pin to a specific version of node is to load directly
-# See https://github.com/nodesource/distributions/issues/33#issuecomment-169345680
-curl -o nodejs.deb https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_16.17.1-deb-1nodesource1_amd64.deb
-apt -y install ./nodejs.deb
-rm ./nodejs.deb
+  nginx-extras \
+  nodejs \
+  unzip \
+  wget
 
 # Make sure nodejs exists
 if ! [[ -f /usr/bin/nodejs ]]

--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -22,7 +22,7 @@ cp $TEMPLATES_PATH/usr/share/keyrings/*.asc /usr/share/keyrings/
 cp $TEMPLATES_PATH/etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/
 
 # Set up the correct node source
-export NODE_VERSION=12
+export NODE_VERSION=14
 envsubst \
   < $TEMPLATES_PATH/etc/apt/sources.list.d/nodesource.sources \
   > /etc/apt/sources.list.d/nodesource.sources
@@ -76,10 +76,6 @@ then
    # It does not exist, so create it
    update-alternatives --quiet --install /usr/bin/nodejs nodejs /usr/bin/node 50 --slave /usr/share/man/man1/nodejs.1.gz nodejs.1.gz /usr/share/man/man1/node.1.gz
 fi
-
-# Update nodejs to version 14
-npm install -g n
-n 14.18.3
 
 # Install dbmate directly, since it isn't packaged
 echo "Install dbmate"

--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -21,6 +21,12 @@ echo "Add custom sources"
 cp $TEMPLATES_PATH/usr/share/keyrings/*.asc /usr/share/keyrings/
 cp $TEMPLATES_PATH/etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/
 
+# Set up the correct node source
+export NODE_VERSION=12
+envsubst \
+  < $TEMPLATES_PATH/etc/apt/sources.list.d/nodesource.sources \
+  > /etc/apt/sources.list.d/nodesource.sources
+
 echo "Install packages"
 apt-get -qq update
 apt-get -qq install -y \

--- a/templates/etc/apt/sources.list.d/nodesource.sources
+++ b/templates/etc/apt/sources.list.d/nodesource.sources
@@ -1,5 +1,5 @@
 Types: deb
-URIs: https://deb.nodesource.com/node_12.x
+URIs: https://deb.nodesource.com/node_${NODE_VERSION}.x
 Suites: buster
 Components: main
 Signed-By: /usr/share/keyrings/nodesource-archive-keyring.asc


### PR DESCRIPTION
This PR makes node versions more configurable via the nodesource apt repo installation strategy and utilizes that approach for installing node 14 in the main image.

It also updates the sftp service to use node 18 (the current active node release).

This should be merged alongside https://github.com/PermanentOrg/sftp-service/pull/230