### PR TITLE
Enable available apache configuration

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -121,8 +121,8 @@ a2enmod \
   mpm_event \
   proxy \
   proxy_fcgi \
-  rewrite
-  setenvif \
+  rewrite \
+  setenvif
 a2enconf \
   charset \
   global-server-name \


### PR DESCRIPTION
Due to a typo in configuration (a dropped backslash), php-fpm's configuration file was not being enabled. Fix the line in the backend provisioner script.

(Previously we thought the configuration wasn't provided entirely and this PR was made to add it, but we realized that the file was there and not being enabled)