### PR TITLE
Double capacity of api instance

### DIFF
--- a/instances/dev/main.tf
+++ b/instances/dev/main.tf
@@ -32,7 +32,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m4.large"
+  instance_type          = "m4.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   private_ip             = "172.31.0.80"

--- a/instances/production/main.tf
+++ b/instances/production/main.tf
@@ -32,7 +32,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m4.large"
+  instance_type          = "m4.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet

--- a/instances/staging/main.tf
+++ b/instances/staging/main.tf
@@ -32,7 +32,7 @@ variable "perm_env" {
 
 resource "aws_instance" "api" {
   ami                    = module.perm_env_data.backend_ami
-  instance_type          = "m4.large"
+  instance_type          = "m4.xlarge"
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet


### PR DESCRIPTION
This PR is another attempt to increase the size of the api server (from `large` to `xlarge`).

Note that we had attempted to move to the `c7g.xlarge` in a previous commit but unfortunately that uses a different chip architecture (ARM).

I noticed that `taskrunner` uses c.xlarge but that is essentially the same price as the m4.xlarge except with half the RAM, so it did not seem like a good choice.