### PR TITLE
Copy all source files on cron and taskrunner configuration

### DIFF
--- a/provisioners/configure-cron.sh
+++ b/provisioners/configure-cron.sh
@@ -19,8 +19,7 @@ echo newrelic-php5 newrelic-php5/license-key string $NEW_RELIC_LICENSE_KEY | deb
 
 echo "Add custom sources"
 cp $TEMPLATES_PATH/usr/share/keyrings/*.asc /usr/share/keyrings/
-cp $TEMPLATES_PATH/etc/apt/sources.list.d/newrelic.sources /etc/apt/sources.list.d/
-cp $TEMPLATES_PATH/etc/apt/sources.list.d/postgresql.sources /etc/apt/sources.list.d/
+cp $TEMPLATES_PATH/etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/
 
 echo "Install packages"
 apt-get -qq update

--- a/provisioners/configure-taskrunner.sh
+++ b/provisioners/configure-taskrunner.sh
@@ -21,8 +21,7 @@ echo newrelic-php5 newrelic-php5/license-key string $NEW_RELIC_LICENSE_KEY | deb
 
 echo "Add custom sources"
 cp $TEMPLATES_PATH/usr/share/keyrings/*.asc /usr/share/keyrings/
-cp $TEMPLATES_PATH/etc/apt/sources.list.d/newrelic.sources /etc/apt/sources.list.d/
-cp $TEMPLATES_PATH/etc/apt/sources.list.d/postgresql.sources /etc/apt/sources.list.d/
+cp $TEMPLATES_PATH/etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/
 
 echo "Install packages"
 apt-get -qq update


### PR DESCRIPTION
Presently, the api server's configure.sh copies all apt source files from the template directory, while the cron and task-runner versions of this script copy only specific ones. This is confusing, especially because we don't build cron and task-runner images as part of the local environment. This commit makes all configure scripts handle apt source files as the api server's does.