### PR TITLE
Upgrade infrastructure to Debian 11

### DIFF
--- a/images/backend.json
+++ b/images/backend.json
@@ -4,5 +4,5 @@
   "hostname": "{{env `PERM_ENV` }}",
   "instance_type": "m4.large",
   "volume_size": "1000",
-  "image_name": "debian-10-amd64-20220911-1135"
+  "image_name": "debian-11-amd64-20220911-1135"
 }

--- a/images/cron.json
+++ b/images/cron.json
@@ -4,5 +4,5 @@
   "hostname": "cron-{{env `PERM_ENV`}}",
   "instance_type": "t2.micro",
   "volume_size": "100",
-  "image_name": "debian-10-amd64-20220911-1135"
+  "image_name": "debian-11-amd64-20220911-1135"
 }

--- a/images/taskrunner.json
+++ b/images/taskrunner.json
@@ -4,5 +4,5 @@
   "hostname": "taskrunner-{{env `PERM_ENV`}}",
   "instance_type": "c4.xlarge",
   "volume_size": "1000",
-  "image_name": "debian-10-amd64-20220911-1135"
+  "image_name": "debian-11-amd64-20220911-1135"
 }

--- a/templates/etc/apt/sources.list.d/nodesource.sources
+++ b/templates/etc/apt/sources.list.d/nodesource.sources
@@ -1,5 +1,5 @@
 Types: deb
 URIs: https://deb.nodesource.com/node_${NODE_VERSION}.x
-Suites: buster
+Suites: bullseye
 Components: main
 Signed-By: /usr/share/keyrings/nodesource-archive-keyring.asc

--- a/templates/etc/apt/sources.list.d/php.sources
+++ b/templates/etc/apt/sources.list.d/php.sources
@@ -1,5 +1,5 @@
 Types: deb
 URIs: https://packages.sury.org/php/
-Suites: buster
+Suites: bullseye
 Components: main
 Signed-By: /usr/share/keyrings/php-archive-keyring.asc

--- a/templates/etc/apt/sources.list.d/postgresql.sources
+++ b/templates/etc/apt/sources.list.d/postgresql.sources
@@ -1,6 +1,6 @@
 Types: deb deb-src
 URIs: http://apt.postgresql.org/pub/repos/apt
-Suites: buster-pgdg
+Suites: bullseye-pgdg
 Components: main
 Signed-By: /usr/share/keyrings/postgresql-archive-keyring.asc
 Architectures: amd64


### PR DESCRIPTION
Debian 10 will pass out of long term support later this year, so this commit upgrades our infrastructure to use Debian 11.