### PR TITLE
Copy assetlinks.json to backend

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -92,12 +92,20 @@ envsubst \
   < $TEMPLATES_PATH/var/www/.aws/config \
   > /var/www/.aws/config
 
+# Create the .well-known directory for mobile site association
+mkdir /var/www/html/.well-known
+
 # This is needed for our iOS app to open links to Permanent in the app
 # https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html
-mkdir /var/www/html/.well-known
 envsubst \
   < $TEMPLATES_PATH/var/www/html/.well-known/apple-app-site-association \
   > /var/www/html/.well-known/apple-app-site-association
+
+# This is needed for our Android app to open links to Permanent in the app
+# https://developer.android.com/training/app-links/verify-android-applinks
+envsubst \
+  < $TEMPLATES_PATH/var/www/html/.well-known/assetlinks.json \
+  > /var/www/html/.well-known/assetlinks.json
 
 # Make www-data the owner of /var/www/ because writing to this dir is required for file conversions
 chown -R www-data /var/www/


### PR DESCRIPTION
The assetlinks.json used for the Android app was included in the .well-known templates, but wasn't actually manually copied over. Copy it over like how we do for the apple-app-site-association file, including filling in any environment variables in the file.