### PR TITLE
Add SSL certificates for AWS RDS to deployed instances

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -95,6 +95,7 @@ jobs:
           FUSION_AUTH_KEY_SFTP: ${{ secrets[matrix.environment.fusion_auth_key_sftp] }}
           FUSION_AUTH_SFTP_CLIENT_ID: ${{ secrets[matrix.environment.fusion_auth_sftp_client_id] }}
           FUSION_AUTH_SFTP_CLIENT_SECRET: ${{ secrets[matrix.environment.fusion_auth_sftp_client_secret] }}
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
   notify:
     runs-on: ubuntu-20.04
     needs: ["build"]

--- a/provisioners/configure-cron.sh
+++ b/provisioners/configure-cron.sh
@@ -12,6 +12,7 @@ if [[ -z "$AWS_REGION" || -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_ACCESS_SECRET" ]]
 fi
 
 echo $PERM_ENV  > /data/www/host.txt
+echo $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
 
 # Preseed responses to New Relic installation questions
 echo newrelic-php5 newrelic-php5/application-name string $NEW_RELIC_APPLICATION_NAME | debconf-set-selections

--- a/provisioners/configure-taskrunner.sh
+++ b/provisioners/configure-taskrunner.sh
@@ -14,6 +14,7 @@ fi
 echo "Install essential software pacakges"
 
 echo $PERM_ENV  > /data/www/host.txt
+echo $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
 
 # Preseed responses to New Relic installation questions
 echo newrelic-php5 newrelic-php5/application-name string $NEW_RELIC_APPLICATION_NAME | debconf-set-selections

--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -12,6 +12,7 @@ if [[ -z "$AWS_REGION" || -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_ACCESS_SECRET" ]]
 fi
 
 echo $PERM_ENV  > /data/www/host.txt
+echo $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
 
 # Preseed responses to New Relic installation questions
 echo newrelic-php5 newrelic-php5/application-name string $NEW_RELIC_APPLICATION_NAME | debconf-set-selections


### PR DESCRIPTION
Presently, we don't use SSL in our database connections. This is a security best practice, so we should. This commit adds the public key certificates for the us-west-2 RDS signing authorities to the images we deploy, so they can be specified as trusted signing authorities when we connect to the database.