### PR TITLE
Remove Zoho integration cron task

### DIFF
--- a/provisioners/deploy-cron.yml
+++ b/provisioners/deploy-cron.yml
@@ -52,6 +52,5 @@
         - daily/account-engagement
         - daily/remove_deleted_records
         - daily/zip_cleanup
-        - daily/zoho_integration
         - weekly/file_upload_summary
         - monthly/validate-md5


### PR DESCRIPTION
The Zoho integration cron task is broken and no longer necessary, so this commit removes it.