### PR TITLE
PER-9743: Update postgres source & apache logs

### DIFF
--- a/templates/etc/apache2/conf-available/global-server-name.conf
+++ b/templates/etc/apache2/conf-available/global-server-name.conf
@@ -1,1 +1,3 @@
 ServerName "localdev"
+LogLevel debug
+LogLevel rewrite:debug

--- a/templates/etc/apache2/conf-available/global-server-name.conf
+++ b/templates/etc/apache2/conf-available/global-server-name.conf
@@ -1,3 +1,1 @@
 ServerName "localdev"
-LogLevel debug
-LogLevel rewrite:debug

--- a/templates/etc/apt/sources.list.d/postgresql.sources
+++ b/templates/etc/apt/sources.list.d/postgresql.sources
@@ -1,6 +1,5 @@
 Types: deb deb-src
-URIs: http://apt.postgresql.org/pub/repos/apt
+URIs: https://apt.postgresql.org/pub/repos/apt
 Suites: bookworm-pgdg
 Components: main
 Signed-By: /usr/share/keyrings/postgresql-archive-keyring.asc
-Architectures: amd64


### PR DESCRIPTION
The postgres source needs to allow installing ARM distributions of the sources.
Configured apache to apache output more logs.