### PR TITLE
VSP-1439[iOS] Reset password deeplink is not working on a tablet

### DIFF
--- a/templates/var/www/html/.well-known/apple-app-site-association
+++ b/templates/var/www/html/.well-known/apple-app-site-association
@@ -28,10 +28,6 @@
             "comment": "Matches archive invite URLs"
           },
           {
-            "/": "/app/fa-reset/*",
-            "comment": "Matches forgot password URLs"
-          },
-          {
             "/": "/app/auth/signup",
             "comment": "Matches signup URL"
           }


### PR DESCRIPTION
  Remove forgot password URLs for deep links on iOS devices.