### PR TITLE
Add Storybook directory to Apache config

### DIFF
--- a/templates/etc/apache2/sites-available/dev.permanent.conf
+++ b/templates/etc/apache2/sites-available/dev.permanent.conf
@@ -109,6 +109,15 @@
         RewriteRule ^ index.html [L]
     </Directory>
 
+    # Static Storybook Config
+    Alias /storybook /data/www/mdot/storybook
+    <Directory "/data/www/mdot/storybook">
+        Require all granted
+        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+        Header set Pragma "no-cache"
+        DirectoryIndex index.html
+    </Directory>
+
     ErrorLog "/var/log/permanent/error.log"
     CustomLog "/var/log/permanent/access.log" vhost_combined
 </VirtualHost>

--- a/templates/etc/apache2/sites-available/local.permanent.conf
+++ b/templates/etc/apache2/sites-available/local.permanent.conf
@@ -84,6 +84,15 @@
         RewriteRule ^(.*)$ index.html [L,QSA]
     </Directory>
 
+    # Static Storybook Config
+    Alias /storybook /data/www/mdot/storybook
+    <Directory "/data/www/mdot/storybook">
+        Require all granted
+        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+        Header set Pragma "no-cache"
+        DirectoryIndex index.html
+    </Directory>
+
     RewriteRule ^/$ /app [last,redirect]
 
     ErrorLog "/var/log/permanent/error.log"

--- a/templates/etc/apache2/sites-available/prod.permanent.conf
+++ b/templates/etc/apache2/sites-available/prod.permanent.conf
@@ -116,6 +116,15 @@
         RewriteRule ^ index.html [L]
     </Directory>
 
+    # Static Storybook Config
+    Alias /storybook /data/www/mdot/storybook
+    <Directory "/data/www/mdot/storybook">
+        Require all granted
+        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+        Header set Pragma "no-cache"
+        DirectoryIndex index.html
+    </Directory>
+
     ErrorLog "/var/log/permanent/error.log"
     CustomLog "/var/log/permanent/access.log" vhost_combined
 

--- a/templates/etc/apache2/sites-available/staging.permanent.conf
+++ b/templates/etc/apache2/sites-available/staging.permanent.conf
@@ -110,6 +110,15 @@
         RewriteRule ^ index.html [L]
     </Directory>
 
+    # Static Storybook Config
+    Alias /storybook /data/www/mdot/storybook
+    <Directory "/data/www/mdot/storybook">
+        Require all granted
+        Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+        Header set Pragma "no-cache"
+        DirectoryIndex index.html
+    </Directory>
+
     ErrorLog "/var/log/permanent/error.log"
     CustomLog "/var/log/permanent/access.log" vhost_combined
 </VirtualHost>


### PR DESCRIPTION
We now upload a built version of Storybook as part of the web-app deploy process. Make this visible on all environments by updating Apache config. To fully make this work we also need to update the load balancers for each environment.