### PR TITLE
Update sftp-service to node 22

### DIFF
--- a/provisioners/configure-sftp.sh
+++ b/provisioners/configure-sftp.sh
@@ -17,7 +17,7 @@ echo "Add custom sources"
 cp $TEMPLATES_PATH/usr/share/keyrings/*.asc /usr/share/keyrings/
 
 # Set up the correct node source
-export NODE_VERSION=18
+export NODE_VERSION=22
 envsubst \
   < $TEMPLATES_PATH/etc/apt/sources.list.d/nodesource.sources \
   > /etc/apt/sources.list.d/nodesource.sources


### PR DESCRIPTION
This PR updates the sftp service provisioner to use Node 22

Issue #165 Update sftp-service to use Node 22