### PR TITLE
Update to Node 22

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -28,7 +28,7 @@ cp $TEMPLATES_PATH/usr/share/keyrings/*.asc /usr/share/keyrings/
 cp $TEMPLATES_PATH/etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/
 
 # Set up the correct node source
-export NODE_VERSION=16
+export NODE_VERSION=22
 envsubst \
   < $TEMPLATES_PATH/etc/apt/sources.list.d/nodesource.sources \
   > /etc/apt/sources.list.d/nodesource.sources


### PR DESCRIPTION
We already moved to Node 22 for sftp; this moves our other backend service runners to 22.