### PR TITLE
Update Github Actions to use Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         machine: [backend, cron, taskrunner, sftp]
@@ -20,7 +20,7 @@ jobs:
           cd images
           packer validate -var-file=${{ matrix.machine }}.json image.json
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: ["validate"]
     strategy:
       matrix:
@@ -100,7 +100,7 @@ jobs:
           FUSION_AUTH_SFTP_CLIENT_ID: ${{ secrets[matrix.environment.fusion_auth_sftp_client_id] }}
           FUSION_AUTH_SFTP_CLIENT_SECRET: ${{ secrets[matrix.environment.fusion_auth_sftp_client_secret] }}
   notify:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: ["build"]
     steps:
       - name: Send Slack notification

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         machine: [backend, cron, taskrunner, sftp]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         machine: [backend, cron, taskrunner, sftp]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         machine: [backend, cron, taskrunner, sftp]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS Credentials


### PR DESCRIPTION
Because Github is retiring support for the Ubuntu 20.04 runners we use now.