### PR TITLE
Stop installing global node packages

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -167,13 +167,6 @@ envsubst \
 
 systemctl enable notification.service
 
-echo "Install node global packages"
-npm install npm@8.17.0 --global
-npm install -g gulp
-npm install -g bower
-npm install -g forever
-npm install -g @angular/cli@7.3.6
-
 mkdir /data/tmp
 mkdir /data/tmp/uploader
 chmod -R 774 /data/tmp


### PR DESCRIPTION
This PR removes an unnecessary configuration step which installs global node modules.

Any node project that needs a module should be installing them directly, and these global modules do not seem to be used by our provisioning scripts.

I also believe the lock-in of npm at 8.17 isn't necessary since npm is installed alongside node to align with whatever version of node we're using.

Resolves #65 