### PR TITLE
Return to using two task runners on staging

### DIFF
--- a/instances/staging/main.tf
+++ b/instances/staging/main.tf
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "api_outage_alarm" {
 resource "aws_instance" "taskrunner" {
   ami                    = module.perm_env_data.taskrunner_ami
   instance_type          = "c4.large"
-  count                  = 10
+  count                  = 2
   vpc_security_group_ids = [module.perm_env_data.security_group]
   monitoring             = true
   subnet_id              = module.perm_env_data.subnet


### PR DESCRIPTION
We boosted the number of task runners on staging as a test. The test is complete, so we can return to just running 2 now.