### PR TITLE
Fix PHP-fpm configuration

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -152,6 +152,8 @@ a2enconf \
   security
 
 # Tune php_fpm
+## Make sure to also review this patch when updating the PHP version, as the
+## line numbers / hunk contents could shift between config versions.
 patch -d /etc/php/8.3/fpm/pool.d < templates/etc/php/8.3/fpm/pool.d/www.conf.patch
 systemctl restart php8.3-fpm.service
 

--- a/templates/etc/php/8.3/fpm/pool.d/www.conf.patch
+++ b/templates/etc/php/8.3/fpm/pool.d/www.conf.patch
@@ -29,3 +29,20 @@
 
  ; The timeout set by 'request_terminate_timeout' ini option is not engaged after
  ; application calls 'fastcgi_finish_request' or when application has finished and
+
+@@ -372,13 +372,13 @@
+ ; The log file for slow requests
+ ; Default Value: not set
+ ; Note: slowlog is mandatory if request_slowlog_timeout is set
+-;slowlog = log/$pool.log.slow
++slowlog = /var/log/php-fpm/$pool.slow.log
+
+ ; The timeout for serving a single request after which a PHP backtrace will be
+ ; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+ ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+ ; Default Value: 0
+-;request_slowlog_timeout = 0
++request_slowlog_timeout = 10s
+
+ ; Depth of slow log stack trace.
+ ; Default Value: 20

--- a/templates/etc/php/8.3/fpm/pool.d/www.conf.patch
+++ b/templates/etc/php/8.3/fpm/pool.d/www.conf.patch
@@ -1,7 +1,7 @@
 @@@ Configure php_fpm to use a larger, fixed number of threads
---- debian/etc/php/7.4/fpm/pool.d/www.conf
-+++ permanent/etc/php/7.4/fpm/pool.d/www.conf
-@@ -100,7 +100,7 @@
+--- www.conf
++++ www.conf
+@@ -113,7 +113,7 @@
  ;             pm.process_idle_timeout   - The number of seconds after which
  ;                                         an idle process will be killed.
  ; Note: This value is mandatory.
@@ -10,7 +10,7 @@
 
  ; The number of child processes to be created when pm is set to 'static' and the
  ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
-@@ -111,7 +111,7 @@
+@@ -124,7 +124,7 @@
  ; forget to tweak pm.* to fit your needs.
  ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
  ; Note: This value is mandatory.

--- a/templates/etc/php/8.3/fpm/pool.d/www.conf.patch
+++ b/templates/etc/php/8.3/fpm/pool.d/www.conf.patch
@@ -19,3 +19,13 @@
 
  ; The number of child processes created on startup.
  ; Note: Used only when pm is set to 'dynamic'
+
+@@ -389,7 +389,7 @@
+ ; does not stop script execution for some reason. A value of '0' means 'off'.
+ ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+ ; Default Value: 0
+-;request_terminate_timeout = 0
++request_terminate_timeout = 60s
+
+ ; The timeout set by 'request_terminate_timeout' ini option is not engaged after
+ ; application calls 'fastcgi_finish_request' or when application has finished and


### PR DESCRIPTION
This PR does three things:

1. It updates the patch command so it will actually apply (regardless of php version / path).  This has the byproduct of increasing the number of fpm threads from 5 to 360.
2. It adds a timeout so deadlocked fpm threads will get killed automatically / re-enter the pool
3. It configures php to start logging if a given thread is slow (longer than 30 seconds)

Resolves #190 

Note: I do not know how to test these changes locally so please review with extra care.