### PR TITLE
Correct template path

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -154,7 +154,7 @@ a2enconf \
 # Tune php_fpm
 ## Make sure to also review this patch when updating the PHP version, as the
 ## line numbers / hunk contents could shift between config versions.
-patch -d /etc/php/8.3/fpm/pool.d < templates/etc/php/8.3/fpm/pool.d/www.conf.patch
+patch -d /etc/php/8.3/fpm/pool.d < $TEMPLATES_PATH/etc/php/8.3/fpm/pool.d/www.conf.patch
 systemctl restart php8.3-fpm.service
 
 echo "Configure Upload Service"


### PR DESCRIPTION
This PR fixes a typo in our template path directory when applying the php configuration patch.

Related to #190