### PR TITLE
#194: Reduce taskrunner volume size

### DIFF
--- a/images/taskrunner.json
+++ b/images/taskrunner.json
@@ -2,7 +2,6 @@
   "configure_script": "configure-taskrunner.sh",
   "deploy_script": "deploy-taskrunner.yml",
   "hostname": "taskrunner-{{env `PERM_ENV`}}",
-  "instance_type": "c4.xlarge",
-  "volume_size": "1000",
+  "volume_size": "100",
   "image_name": "debian-12-amd64-20240429-1732"
 }


### PR DESCRIPTION
Reduce the taskrunner external storage volume to 100GB instead of 1000GB, for cost reasons. I also removed the "instance_type" line since I think that is determined in the main.tf file for each environment (note that staging has a smaller instance now). That is an experimental change, though.