### PR TITLE
#194: Return instance type

### DIFF
--- a/images/taskrunner.json
+++ b/images/taskrunner.json
@@ -2,6 +2,7 @@
   "configure_script": "configure-taskrunner.sh",
   "deploy_script": "deploy-taskrunner.yml",
   "hostname": "taskrunner-{{env `PERM_ENV`}}",
+  "instance_type": "c4.xlarge",
   "volume_size": "100",
   "image_name": "debian-12-amd64-20240429-1732"
 }


### PR DESCRIPTION
Image build failed and [said that instance type is required](https://github.com/PermanentOrg/infrastructure/actions/runs/16501091752/job/46659587183), so adding it back in.