### PR TITLE
Remove unneeded cronjob

### DIFF
--- a/provisioners/deploy-cron.yml
+++ b/provisioners/deploy-cron.yml
@@ -50,7 +50,6 @@
         - minute/notification-runner
         - hourly/system-check
         - daily/account-engagement
-        - daily/remove_deleted_records
         - daily/zip_cleanup
         - weekly/file_upload_summary
         - monthly/validate-md5


### PR DESCRIPTION
We [deleted a
cronjob](https://github.com/PermanentOrg/back-end/commit/bdc3ff80db4b19dec22cfd8749fa753b092e8b24), leading to image build failure because it couldn't find the script. Remove the reference to the cronjob.