### PR TITLE
Increase shared volume size for the dev archivematica instance

### DIFF
--- a/archivematica/test_cluster/dev_archivematica_deployment.tf
+++ b/archivematica/test_cluster/dev_archivematica_deployment.tf
@@ -739,11 +739,11 @@ resource "kubernetes_persistent_volume_claim" "archivematica_dev_pipeline_data_p
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
-        storage = "2Gi"
+        storage = "8Gi"
       }
     }
 
-    storage_class_name = "gp2"
+    storage_class_name = "gp3"
   }
 }
 

--- a/archivematica/test_cluster/eks-cluster.tf
+++ b/archivematica/test_cluster/eks-cluster.tf
@@ -68,6 +68,19 @@ module "eks" {
   }
 }
 
+resource "kubernetes_storage_class" "gp3" {
+  metadata {
+    name = "gp3"
+  }
+  storage_provisioner = "ebs.csi.aws.com"
+  parameters = {
+    type = "gp3"
+  }
+  reclaim_policy = "Delete"
+  volume_binding_mode = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+}
+
 resource "kubernetes_cluster_role_binding" "eks_admins_cluster_admin" {
   metadata {
     name = "eks-admins-cluster-admin"


### PR DESCRIPTION
The dev archivematica instance recently ran out of space in one of its shared volumes. This commit updates the terraform to enlarge it. To achieve this we have to add the gp3 storage class and update the volume to use it, because gp2 volumes aren't resizable.