### PR TITLE
Increase PHP memory limit

### DIFF
--- a/provisioners/configure.sh
+++ b/provisioners/configure.sh
@@ -155,7 +155,9 @@ a2enconf \
 ## Make sure to also review this patch when updating the PHP version, as the
 ## line numbers / hunk contents could shift between config versions.
 patch -d /etc/php/8.3/fpm/pool.d < $TEMPLATES_PATH/etc/php/8.3/fpm/pool.d/www.conf.patch
+patch /etc/php/8.3/fpm/php.ini < $TEMPLATES_PATH/etc/php/8.3/fpm/php.ini/php.patch
 systemctl restart php8.3-fpm.service
+systemctl restart apache2.service
 
 echo "Configure Upload Service"
 envsubst \

--- a/templates/etc/php/8.3/fpm/php.ini/php.patch
+++ b/templates/etc/php/8.3/fpm/php.ini/php.patch
@@ -1,0 +1,21 @@
+@@@ Extend timeouts and memory limits
+--- php.ini
++++ php.ini
+@@ -442,7 +442,7 @@
+
+ ; Maximum amount of memory a script may consume
+ ; https://php.net/memory-limit
+-memory_limit = 128M
++memory_limit = 1024M
+
+ ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+ ; Error handling and logging ;
+@@ -1468,7 +1468,7 @@
+ ; After this number of seconds, stored data will be seen as 'garbage' and
+ ; cleaned up by the garbage collection process.
+ ; https://php.net/session.gc-maxlifetime
+-session.gc_maxlifetime = 1440
++session.gc_maxlifetime = 2592000
+
+ ; NOTE: If you are using the subdirectory option for storing session files
+ ;       (see session.save_path above), then garbage collection does *not*


### PR DESCRIPTION
Currently, some users of permanent have folders large enough that retrieving all their contents via the API causes PHP to run out of memory. The correct way to fix this is to paginate those API calls, but as a hotfix, this commit increases the memory limit so users will still be able to access their files.

Since this commit adds a patch for the php.ini config file, it also includes the update to gc_maxlifetime that we've historically made manually on every deploy.