### PR TITLE
PER-10242: Move dev app server location

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -69,5 +69,5 @@ export NEW_RELIC_LICENSE_KEY=
 export FUSION_AUTH_HOST=${FUSION_AUTH_HOST}
 export FUSION_AUTH_KEY_SFTP=${FUSION_AUTH_KEY_SFTP}
 
-# The location of the permanent server (e.g. "dev.permanent.org")
+# The location of the permanent server (e.g. "app.dev.permanent.org")
 export SERVER_DOMAIN=${SERVER_DOMAIN}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,7 +29,7 @@ jobs:
         machine: [backend, taskrunner, cron, sftp]
         environment:
           - perm_env: dev
-            server_domain: "dev.permanent.org"
+            server_domain: "app.dev.permanent.org"
             stela_domain: "api.dev.permanent.org"
             app_id: "TEST.org.permanent.permanent.dev"
             aws_deploy_key: DEV_AWS_ACCESS_KEY_ID

--- a/templates/etc/apache2/sites-available/dev.permanent.conf
+++ b/templates/etc/apache2/sites-available/dev.permanent.conf
@@ -1,11 +1,11 @@
 <VirtualHost *:80>
-    ServerName dev.permrecord.org
-    ServerAlias dev.permrecord.com
-    Redirect / https://dev.permanent.org/
+    ServerName app.dev.permrecord.org
+    ServerAlias app.dev.permrecord.com
+    Redirect / https://app.dev.permanent.org/
 </VirtualHost>
 
 <VirtualHost *:80>
-    ServerName dev.permanent.org
+    ServerName app.dev.permanent.org
 
     SetEnv AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
     SetEnv AWS_SECRET_ACCESS_KEY "${AWS_ACCESS_SECRET}"


### PR DESCRIPTION
I made this change on the dev back-end box manually to test it. Without this, we were stuck in a 301->302 loop as WPEngine sent specific paths to AWS and then the redirect here sent traffic back to WPEngine.

There may be more work to follow on dev, but I wanted to make sure this initial manual change was recorded.