### PR TITLE
Increase disk space on Archivematica nodes

### DIFF
--- a/archivematica/prod_cluster/eks-cluster.tf
+++ b/archivematica/prod_cluster/eks-cluster.tf
@@ -67,7 +67,7 @@ module "eks" {
         xvda = {
           device_name = "/dev/xvda"
           ebs = {
-            volume_size           = 32
+            volume_size           = 64
             volume_type           = "gp2"
             delete_on_termination = true
             encrypted             = true


### PR DESCRIPTION
Recently our production instance of Archivematica went down because the kubelet process on one of its nodes died. This is usually a symptom of running out of disk space, and though we don't have logs of disk usage specifically the node was under heavy CPU load when kubelet went down, and in Archivematica heavy CPU load often correlates with processing many or very large files. Thus, this commit increases the size of the volumes attached to the production Archivematica nodes.