### PR TITLE
Update kubernetes to 1.33

### DIFF
--- a/archivematica/prod_cluster/eks-cluster.tf
+++ b/archivematica/prod_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.32"
+  kubernetes_version = "1.33"
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.subnet_ids

--- a/archivematica/test_cluster/eks-cluster.tf
+++ b/archivematica/test_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.32"
+  kubernetes_version = "1.33"
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.subnet_ids


### PR DESCRIPTION
Currently our Archivematica clusters run on kubernetes 1.32, but this is leaving standard support on EKS later this quarter. Thus, this commit updates the clusters to 1.33.