### PR TITLE
Scale up MCP clients on Archivematica

### DIFF
--- a/archivematica/prod_cluster/archivematica_deployment.tf
+++ b/archivematica/prod_cluster/archivematica_deployment.tf
@@ -9,7 +9,7 @@ data "kubernetes_resource" "archivematica_prod" {
   kind        = "Deployment"
   api_version = "apps/v1"
   metadata {
-    name = "archivematica-prod"
+    name      = "archivematica-prod"
     namespace = kubernetes_namespace.archivematica_prod.metadata[0].name
   }
 }
@@ -581,7 +581,7 @@ data "kubernetes_resource" "mcp_client_prod" {
   kind        = "Deployment"
   api_version = "apps/v1"
   metadata {
-    name = "archivematica-mcp-client-prod"
+    name      = "archivematica-mcp-client-prod"
     namespace = kubernetes_namespace.archivematica_prod.metadata[0].name
   }
 }
@@ -596,7 +596,7 @@ resource "kubernetes_deployment" "mcp_client_prod" {
     namespace = kubernetes_namespace.archivematica_prod.metadata[0].name
   }
   spec {
-    replicas = 4
+    replicas = 10
     selector {
       match_labels = {
         App = "archivematica-mcp-client-prod"

--- a/archivematica/test_cluster/dev_archivematica_deployment.tf
+++ b/archivematica/test_cluster/dev_archivematica_deployment.tf
@@ -9,7 +9,7 @@ data "kubernetes_resource" "archivematica_dev" {
   kind        = "Deployment"
   api_version = "apps/v1"
   metadata {
-    name = "archivematica-dev"
+    name      = "archivematica-dev"
     namespace = kubernetes_namespace.archivematica_dev.metadata[0].name
   }
 }
@@ -581,7 +581,7 @@ data "kubernetes_resource" "mcp_client_dev" {
   kind        = "Deployment"
   api_version = "apps/v1"
   metadata {
-    name = "archivematica-mcp-client-dev"
+    name      = "archivematica-mcp-client-dev"
     namespace = kubernetes_namespace.archivematica_dev.metadata[0].name
   }
 }
@@ -596,7 +596,7 @@ resource "kubernetes_deployment" "mcp_client_dev" {
     namespace = kubernetes_namespace.archivematica_dev.metadata[0].name
   }
   spec {
-    replicas = 4
+    replicas = 10
     selector {
       match_labels = {
         App = "archivematica-mcp-client-dev"

--- a/archivematica/test_cluster/staging_archivematica_deployment.tf
+++ b/archivematica/test_cluster/staging_archivematica_deployment.tf
@@ -9,7 +9,7 @@ data "kubernetes_resource" "archivematica_staging" {
   kind        = "Deployment"
   api_version = "apps/v1"
   metadata {
-    name = "archivematica-staging"
+    name      = "archivematica-staging"
     namespace = kubernetes_namespace.archivematica_staging.metadata[0].name
   }
 }
@@ -378,7 +378,7 @@ resource "kubernetes_deployment" "archivematica_staging" {
           }
         }
         init_container {
-          image   = local.desired_images["archivematica-storage-service-staging"]
+          image = local.desired_images["archivematica-storage-service-staging"]
           name  = "archivematica-storage-service-create-user"
           env {
             name  = "DJANGO_SETTINGS_MODULE"
@@ -581,7 +581,7 @@ data "kubernetes_resource" "mcp_client_staging" {
   kind        = "Deployment"
   api_version = "apps/v1"
   metadata {
-    name = "archivematica-mcp-client-staging"
+    name      = "archivematica-mcp-client-staging"
     namespace = kubernetes_namespace.archivematica_staging.metadata[0].name
   }
 }
@@ -596,7 +596,7 @@ resource "kubernetes_deployment" "mcp_client_staging" {
     namespace = kubernetes_namespace.archivematica_staging.metadata[0].name
   }
   spec {
-    replicas = 4
+    replicas = 10
     selector {
       match_labels = {
         App = "archivematica-mcp-client-staging"


### PR DESCRIPTION
Currently, our production deployment of Archivematica is processing files at about half the rate that Archivematica did in our initial tests. To correct this, this commit scales up the number of MCP clients our Archivematica deployments use from 4 to 10.