### PR TITLE
Turn off hot reloading on Archivematica deployments

### DIFF
--- a/archivematica/prod_cluster/archivematica_deployment.tf
+++ b/archivematica/prod_cluster/archivematica_deployment.tf
@@ -68,14 +68,6 @@ resource "kubernetes_deployment" "archivematica_prod" {
             value = "/dev/null"
           }
           env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
-          }
-          env {
             name = "SS_DB_URL"
             value_from {
               secret_key_ref {
@@ -154,14 +146,6 @@ resource "kubernetes_deployment" "archivematica_prod" {
           env {
             name  = "AM_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name  = "AM_GUNICORN_LOGLEVEL"
@@ -359,14 +343,6 @@ resource "kubernetes_deployment" "archivematica_prod" {
             value = "/dev/null"
           }
           env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
-          }
-          env {
             name = "SS_DB_URL"
             value_from {
               secret_key_ref {
@@ -395,14 +371,6 @@ resource "kubernetes_deployment" "archivematica_prod" {
           env {
             name  = "SS_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name = "SS_DB_URL"
@@ -461,14 +429,6 @@ resource "kubernetes_deployment" "archivematica_prod" {
           env {
             name  = "AM_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name  = "ARCHIVEMATICA_DASHBOARD_EMAIL_PORT"

--- a/archivematica/test_cluster/dev_archivematica_deployment.tf
+++ b/archivematica/test_cluster/dev_archivematica_deployment.tf
@@ -68,14 +68,6 @@ resource "kubernetes_deployment" "archivematica_dev" {
             value = "/dev/null"
           }
           env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
-          }
-          env {
             name = "SS_DB_URL"
             value_from {
               secret_key_ref {
@@ -154,14 +146,6 @@ resource "kubernetes_deployment" "archivematica_dev" {
           env {
             name  = "AM_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name  = "AM_GUNICORN_LOGLEVEL"
@@ -359,14 +343,6 @@ resource "kubernetes_deployment" "archivematica_dev" {
             value = "/dev/null"
           }
           env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
-          }
-          env {
             name = "SS_DB_URL"
             value_from {
               secret_key_ref {
@@ -395,14 +371,6 @@ resource "kubernetes_deployment" "archivematica_dev" {
           env {
             name  = "SS_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name = "SS_DB_URL"
@@ -461,14 +429,6 @@ resource "kubernetes_deployment" "archivematica_dev" {
           env {
             name  = "AM_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name  = "ARCHIVEMATICA_DASHBOARD_EMAIL_PORT"

--- a/archivematica/test_cluster/staging_archivematica_deployment.tf
+++ b/archivematica/test_cluster/staging_archivematica_deployment.tf
@@ -68,14 +68,6 @@ resource "kubernetes_deployment" "archivematica_staging" {
             value = "/dev/null"
           }
           env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
-          }
-          env {
             name = "SS_DB_URL"
             value_from {
               secret_key_ref {
@@ -154,14 +146,6 @@ resource "kubernetes_deployment" "archivematica_staging" {
           env {
             name  = "AM_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name  = "AM_GUNICORN_LOGLEVEL"
@@ -359,14 +343,6 @@ resource "kubernetes_deployment" "archivematica_staging" {
             value = "/staging/null"
           }
           env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
-          }
-          env {
             name = "SS_DB_URL"
             value_from {
               secret_key_ref {
@@ -395,14 +371,6 @@ resource "kubernetes_deployment" "archivematica_staging" {
           env {
             name  = "SS_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "SS_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name = "SS_DB_URL"
@@ -461,14 +429,6 @@ resource "kubernetes_deployment" "archivematica_staging" {
           env {
             name  = "AM_GUNICORN_ACCESSLOG"
             value = "/dev/null"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD"
-            value = "true"
-          }
-          env {
-            name  = "AM_GUNICORN_RELOAD_ENGINE"
-            value = "auto"
           }
           env {
             name  = "ARCHIVEMATICA_DASHBOARD_EMAIL_PORT"


### PR DESCRIPTION
Currently our Archivematica deployments have Gunicorn hot reloading enabled for the dashboard and storage service. This is unnecessary since we aren't live-editting code in deployed environments. Worse, the reloads seem to occasionally trigger due to non-code changes in the filesystem, which causes the dashboard and storage service to be momentarily unavailable, which can cause file processing to fail.