### PR TITLE
Increase WORKER_THREADS to 4 for the MPC server

### DIFF
--- a/archivematica/prod_cluster/archivematica_deployment.tf
+++ b/archivematica/prod_cluster/archivematica_deployment.tf
@@ -296,7 +296,7 @@ resource "kubernetes_deployment" "archivematica_prod" {
           }
           env {
             name  = "ARCHIVEMATICA_MCPSERVER_MCPSERVER_WORKER_THREADS"
-            value = "1"
+            value = "4"
           }
           env {
             name  = "ARCHIVEMATICA_MCPSERVER_MCPSERVER_CONCURRENT_PACKAGES"

--- a/archivematica/test_cluster/dev_archivematica_deployment.tf
+++ b/archivematica/test_cluster/dev_archivematica_deployment.tf
@@ -296,7 +296,7 @@ resource "kubernetes_deployment" "archivematica_dev" {
           }
           env {
             name  = "ARCHIVEMATICA_MCPSERVER_MCPSERVER_WORKER_THREADS"
-            value = "1"
+            value = "4"
           }
           env {
             name  = "ARCHIVEMATICA_MCPSERVER_MCPSERVER_CONCURRENT_PACKAGES"

--- a/archivematica/test_cluster/staging_archivematica_deployment.tf
+++ b/archivematica/test_cluster/staging_archivematica_deployment.tf
@@ -296,7 +296,7 @@ resource "kubernetes_deployment" "archivematica_staging" {
           }
           env {
             name  = "ARCHIVEMATICA_MCPSERVER_MCPSERVER_WORKER_THREADS"
-            value = "1"
+            value = "4"
           }
           env {
             name  = "ARCHIVEMATICA_MCPSERVER_MCPSERVER_CONCURRENT_PACKAGES"


### PR DESCRIPTION
Several months ago, we set our MCP server's WORKER_THREADS to 1 in an effort to diagnose a bug, and we never restored it to its default value. This commit does so, which will hopefully help address some of the performance issues we're seeing with our Archivematica deployment.