### PR TITLE
Add New Relic integration for Kubernetes

### DIFF
--- a/archivematica/prod_cluster/newrelic.tf
+++ b/archivematica/prod_cluster/newrelic.tf
@@ -1,0 +1,37 @@
+resource "helm_release" "newrelic" {
+  name             = "newrelic"
+  repository       = "https://helm-charts.newrelic.com"
+  chart            = "nri-bundle"
+  namespace        = "newrelic"
+  create_namespace = true
+
+  set_sensitive {
+    name  = "global.licenseKey"
+    value = var.new_relic_license_key
+  }
+
+  set {
+    name  = "global.cluster"
+    value = module.eks.cluster_name
+  }
+
+  set {
+    name  = "kube-state-metrics.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "nri-kube-events.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "newrelic-logging.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "newrelic-prometheus-agent.enabled"
+    value = "true"
+  }
+}

--- a/archivematica/prod_cluster/variables.tf
+++ b/archivematica/prod_cluster/variables.tf
@@ -83,3 +83,8 @@ variable "alert_email" {
   type        = string
   default     = "engineering@permanent.org"
 }
+
+variable "new_relic_license_key" {
+  description = "New Relic license key"
+  type        = string
+}

--- a/archivematica/test_cluster/newrelic.tf
+++ b/archivematica/test_cluster/newrelic.tf
@@ -1,0 +1,37 @@
+resource "helm_release" "newrelic" {
+  name             = "newrelic"
+  repository       = "https://helm-charts.newrelic.com"
+  chart            = "nri-bundle"
+  namespace        = "newrelic"
+  create_namespace = true
+
+  set_sensitive {
+    name  = "global.licenseKey"
+    value = var.new_relic_license_key
+  }
+
+  set {
+    name  = "global.cluster"
+    value = module.eks.cluster_name
+  }
+
+  set {
+    name  = "kube-state-metrics.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "nri-kube-events.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "newrelic-logging.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "newrelic-prometheus-agent.enabled"
+    value = "true"
+  }
+}

--- a/archivematica/test_cluster/variables.tf
+++ b/archivematica/test_cluster/variables.tf
@@ -135,3 +135,8 @@ variable "alert_email" {
   type        = string
   default     = "engineering@permanent.org"
 }
+
+variable "new_relic_license_key" {
+  description = "New Relic license key"
+  type        = string
+}


### PR DESCRIPTION
This commit adds New Relic monitoring to our Archivematica Kubernetes clusters, in the interest of centralizing monitoring data in New Relic.