### PR TITLE
Fix the cloudwatch cluster scraper pod

### DIFF
--- a/archivematica/prod_cluster/eks-cluster.tf
+++ b/archivematica/prod_cluster/eks-cluster.tf
@@ -109,6 +109,7 @@ module "cloudwatch_observability_irsa" {
 
       namespace_service_accounts = [
         "amazon-cloudwatch:cloudwatch-agent",
+        "amazon-cloudwatch:cloudwatch-agent-cluster-scraper",
         "amazon-cloudwatch:adot-collector",
       ]
     }

--- a/archivematica/test_cluster/eks-cluster.tf
+++ b/archivematica/test_cluster/eks-cluster.tf
@@ -141,6 +141,7 @@ module "cloudwatch_observability_irsa" {
 
       namespace_service_accounts = [
         "amazon-cloudwatch:cloudwatch-agent",
+        "amazon-cloudwatch:cloudwatch-agent-cluster-scraper",
         "amazon-cloudwatch:adot-collector",
       ]
     }


### PR DESCRIPTION
Currently, the cloudwatch cluster scraper pod, which is part of the cloudwatch monitoring used by this cluster, is crashing due to a permissions error. This is because it's using a different service account than it used to; this commit adds the new service account to the set of accounts we grant permissions to.