### PR TITLE
Fix infrastructure deploys

### DIFF
--- a/instances/modules/get-data/main.tf
+++ b/instances/modules/get-data/main.tf
@@ -44,4 +44,5 @@ data "aws_security_group" "default" {
 
 data "aws_subnet" "default" {
   availability_zone = var.perm_env.zone
+  default_for_az    = true
 }


### PR DESCRIPTION
Adding subnets to support Lambda logging has broken the Terraform in this repo. This commit updates that terraform so it can still find the subnets it wants to deploy to.