### PR TITLE
Increase Archivematica's sharedDirectory volume size on staging

### DIFF
--- a/archivematica/test_cluster/staging_archivematica_deployment.tf
+++ b/archivematica/test_cluster/staging_archivematica_deployment.tf
@@ -724,11 +724,11 @@ resource "kubernetes_persistent_volume_claim" "archivematica_staging_pipeline_da
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
-        storage = "2Gi"
+        storage = "16Gi"
       }
     }
 
-    storage_class_name = "gp2"
+    storage_class_name = "gp3"
   }
 }
 


### PR DESCRIPTION
Currently, our staging instance of Archivematica has a 2GB volume to use as its sharedDirectory. This appears to be too small, as it has filled up and stopped our staging Archivematica instance from processing files. This commit boosts the size of this volume to 16GB, which matches the dev environment.