### PR TITLE
Increase the size of the prod-staging-data volume in Archivematica

### DIFF
--- a/archivematica/prod_cluster/archivematica_deployment.tf
+++ b/archivematica/prod_cluster/archivematica_deployment.tf
@@ -741,11 +741,11 @@ resource "kubernetes_persistent_volume_claim" "archivematica_prod_staging_data_p
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
-        storage = "64Gi"
+        storage = "128Gi"
       }
     }
 
-    storage_class_name = "gp2"
+    storage_class_name = "gp3"
   }
 }
 

--- a/archivematica/prod_cluster/eks-cluster.tf
+++ b/archivematica/prod_cluster/eks-cluster.tf
@@ -78,6 +78,19 @@ module "eks" {
   }
 }
 
+resource "kubernetes_storage_class" "gp3" {
+  metadata {
+    name = "gp3"
+  }
+  storage_provisioner = "ebs.csi.aws.com"
+  parameters = {
+    type = "gp3"
+  }
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+}
+
 module "ebs_csi_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.60.0"


### PR DESCRIPTION
The prod-staging-data volume is presently out of storage. If this can happen, it should probably be bigger, so this commit doubles its size.