### PR TITLE
Increase prod pipeline volume size in Archivematica cluster

### DIFF
--- a/archivematica/prod_cluster/archivematica_deployment.tf
+++ b/archivematica/prod_cluster/archivematica_deployment.tf
@@ -724,11 +724,11 @@ resource "kubernetes_persistent_volume_claim" "archivematica_prod_pipeline_data_
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
-        storage = "256Gi"
+        storage = "512Gi"
       }
     }
 
-    storage_class_name = "gp2"
+    storage_class_name = "gp3"
   }
 }
 


### PR DESCRIPTION
Currently, our production deployment of Archivematica is down because it's prod-pipeline volume has run out of space. This commit resolves that problem by doubling the size of that volume.