### PR TITLE
Add volume usage alerting to the Archivematica clusters

### DIFF
--- a/archivematica/prod_cluster/main.tf
+++ b/archivematica/prod_cluster/main.tf
@@ -29,6 +29,12 @@ provider "aws" {
   region = var.region
 }
 
+provider "newrelic" {
+  account_id = var.new_relic_account_id
+  api_key    = var.new_relic_api_key
+  region     = "US"
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/archivematica/prod_cluster/newrelic_alerts.tf
+++ b/archivematica/prod_cluster/newrelic_alerts.tf
@@ -1,0 +1,70 @@
+resource "newrelic_alert_policy" "pv_usage" {
+  name                = "prod-archivematica-pv-usage"
+  incident_preference = "PER_CONDITION_AND_TARGET"
+}
+
+resource "newrelic_nrql_alert_condition" "pv_usage_high" {
+  account_id  = var.new_relic_account_id
+  policy_id   = newrelic_alert_policy.pv_usage.id
+  name        = "prod-archivematica-pv-usage-high"
+  description = "Alert when a persistent volume in the prod Archivematica cluster exceeds 90% capacity"
+  enabled     = true
+
+  nrql {
+    query = "FROM K8sVolumeSample SELECT (average(fsUsedBytes) / average(fsCapacityBytes)) * 100 WHERE clusterName = '${module.eks.cluster_name}' FACET pvcName, namespaceName"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = 90
+    threshold_duration    = 300
+    threshold_occurrences = "ALL"
+  }
+
+  fill_option        = "last_value"
+  aggregation_window = 60
+  aggregation_method = "event_flow"
+  aggregation_delay  = 120
+}
+
+resource "newrelic_notification_destination" "pv_usage_email" {
+  name = "prod-archivematica-pv-usage-email"
+  type = "EMAIL"
+
+  property {
+    key   = "email"
+    value = var.alert_email
+  }
+}
+
+resource "newrelic_notification_channel" "pv_usage_email" {
+  name           = "prod-archivematica-pv-usage-email"
+  type           = "EMAIL"
+  destination_id = newrelic_notification_destination.pv_usage_email.id
+  product        = "IINT"
+
+  property {
+    key   = "subject"
+    value = "Persistent volume usage alert: prod Archivematica cluster"
+  }
+}
+
+resource "newrelic_workflow" "pv_usage" {
+  name                  = "prod-archivematica-pv-usage"
+  muting_rules_handling = "NOTIFY_ALL_ISSUES"
+
+  issues_filter {
+    name = "policy-filter"
+    type = "FILTER"
+
+    predicate {
+      attribute = "labels.policyIds"
+      operator  = "EXACTLY_MATCHES"
+      values    = [tostring(newrelic_alert_policy.pv_usage.id)]
+    }
+  }
+
+  destination {
+    channel_id = newrelic_notification_channel.pv_usage_email.id
+  }
+}

--- a/archivematica/prod_cluster/terraform.tf
+++ b/archivematica/prod_cluster/terraform.tf
@@ -37,6 +37,11 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.9.0"
     }
+
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "~> 3.0"
+    }
   }
 
   required_version = "~> 1.5"

--- a/archivematica/prod_cluster/variables.tf
+++ b/archivematica/prod_cluster/variables.tf
@@ -88,3 +88,13 @@ variable "new_relic_license_key" {
   description = "New Relic license key"
   type        = string
 }
+
+variable "new_relic_account_id" {
+  description = "New Relic account ID"
+  type        = number
+}
+
+variable "new_relic_api_key" {
+  description = "New Relic User API key for Terraform provider"
+  type        = string
+}

--- a/archivematica/test_cluster/main.tf
+++ b/archivematica/test_cluster/main.tf
@@ -29,6 +29,12 @@ provider "aws" {
   region = var.region
 }
 
+provider "newrelic" {
+  account_id = var.new_relic_account_id
+  api_key    = var.new_relic_api_key
+  region     = "US"
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/archivematica/test_cluster/newrelic_alerts.tf
+++ b/archivematica/test_cluster/newrelic_alerts.tf
@@ -1,0 +1,70 @@
+resource "newrelic_alert_policy" "pv_usage" {
+  name                = "dev-archivematica-pv-usage"
+  incident_preference = "PER_CONDITION_AND_TARGET"
+}
+
+resource "newrelic_nrql_alert_condition" "pv_usage_high" {
+  account_id  = var.new_relic_account_id
+  policy_id   = newrelic_alert_policy.pv_usage.id
+  name        = "dev-archivematica-pv-usage-high"
+  description = "Alert when a persistent volume in the dev/staging Archivematica cluster exceeds 90% capacity"
+  enabled     = true
+
+  nrql {
+    query = "FROM K8sVolumeSample SELECT (average(fsUsedBytes) / average(fsCapacityBytes)) * 100 WHERE clusterName = '${module.eks.cluster_name}' FACET pvcName, namespaceName"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = 90
+    threshold_duration    = 300
+    threshold_occurrences = "ALL"
+  }
+
+  fill_option        = "last_value"
+  aggregation_window = 60
+  aggregation_method = "event_flow"
+  aggregation_delay  = 120
+}
+
+resource "newrelic_notification_destination" "pv_usage_email" {
+  name = "dev-archivematica-pv-usage-email"
+  type = "EMAIL"
+
+  property {
+    key   = "email"
+    value = var.alert_email
+  }
+}
+
+resource "newrelic_notification_channel" "pv_usage_email" {
+  name           = "dev-archivematica-pv-usage-email"
+  type           = "EMAIL"
+  destination_id = newrelic_notification_destination.pv_usage_email.id
+  product        = "IINT"
+
+  property {
+    key   = "subject"
+    value = "Persistent volume usage alert: dev/staging Archivematica cluster"
+  }
+}
+
+resource "newrelic_workflow" "pv_usage" {
+  name                  = "dev-archivematica-pv-usage"
+  muting_rules_handling = "NOTIFY_ALL_ISSUES"
+
+  issues_filter {
+    name = "policy-filter"
+    type = "FILTER"
+
+    predicate {
+      attribute = "labels.policyIds"
+      operator  = "EXACTLY_MATCHES"
+      values    = [tostring(newrelic_alert_policy.pv_usage.id)]
+    }
+  }
+
+  destination {
+    channel_id = newrelic_notification_channel.pv_usage_email.id
+  }
+}

--- a/archivematica/test_cluster/terraform.tf
+++ b/archivematica/test_cluster/terraform.tf
@@ -37,6 +37,11 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.9.0"
     }
+
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "~> 3.0"
+    }
   }
 
   required_version = "~> 1.5"

--- a/archivematica/test_cluster/variables.tf
+++ b/archivematica/test_cluster/variables.tf
@@ -140,3 +140,13 @@ variable "new_relic_license_key" {
   description = "New Relic license key"
   type        = string
 }
+
+variable "new_relic_account_id" {
+  description = "New Relic account ID"
+  type        = number
+}
+
+variable "new_relic_api_key" {
+  description = "New Relic User API key for Terraform provider"
+  type        = string
+}


### PR DESCRIPTION
We've sometimes seen Archivematica volumes run out of space, causing Archivematica to stop working. To prevent such outages in the future, this commit adds NewRelic alerting to notify us when any Archivematica volume usage reaches 90% of its capacity.