### PR TITLE
Increase staging data volume size in staging environment

### DIFF
--- a/archivematica/test_cluster/staging_archivematica_deployment.tf
+++ b/archivematica/test_cluster/staging_archivematica_deployment.tf
@@ -741,11 +741,11 @@ resource "kubernetes_persistent_volume_claim" "archivematica_staging_staging_dat
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
-        storage = "2Gi"
+        storage = "16Gi"
       }
     }
 
-    storage_class_name = "gp2"
+    storage_class_name = "gp3"
   }
 }
 


### PR DESCRIPTION
Currently Archivematica isn't working on our staging environment because it's staging data volume is full; this commit increases the volume size to avoid this problem.