### PR TITLE
Pin packer-plugin-amazon to 1.8.0

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install packer plugins
         run: |
-          packer plugins install "github.com/hashicorp/amazon"
+          packer plugins install "github.com/hashicorp/amazon" "1.8.0"
           packer plugins install "github.com/hashicorp/ansible"
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.CKRUM_PAT }}
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install packer plugins
         run: |
-          packer plugins install "github.com/hashicorp/amazon"
+          packer plugins install "github.com/hashicorp/amazon" "1.8.0"
           packer plugins install "github.com/hashicorp/ansible"
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.CKRUM_PAT }}


### PR DESCRIPTION
The 1.8.1 release of this plugin made certain SSH operations much slower (https://github.com/hashicorp/packer-plugin-amazon/issues/678); this seems to break our builds. This commit pins the plugin to 1.8.0 to avoid that issue.