### PR TITLE
Update Archivematica Kubernetes cluster to 1.34

### DIFF
--- a/archivematica/prod_cluster/eks-cluster.tf
+++ b/archivematica/prod_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.33"
+  kubernetes_version = "1.34"
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.subnet_ids

--- a/archivematica/test_cluster/eks-cluster.tf
+++ b/archivematica/test_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.33"
+  kubernetes_version = "1.34"
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.subnet_ids


### PR DESCRIPTION
Kubernetes 1.33 will shortly leave EKS standard support, so this commit updates our Archivematica Kubernetes cluster to 1.34.