### PR TITLE
Set TMPDIR to /data/tmp on taskrunners

### DIFF
--- a/provisioners/configure-taskrunner.sh
+++ b/provisioners/configure-taskrunner.sh
@@ -101,6 +101,10 @@ chmod -R 774 /data/tmp
 chown -R www-data /data/tmp
 chgrp -R $APP_USER /data/tmp
 
+# Redirect any temp file creation that doesn't explicitly target /data/tmp
+# (e.g. system default temp dir lookups) away from the small root volume
+echo "TMPDIR=/data/tmp" >> /etc/environment
+
 # For the deployer user to download packages from S3
 cp -R /var/www/.aws /home/$APP_USER/
 chown -R $APP_USER /home/$APP_USER/.aws


### PR DESCRIPTION
Currently, our taskrunners create some temporary files in /tmp, which lives on their 8 GB drive, rather than /data/tmp, which lives on a 1 TB drive. This causes the 8 GB drive to fill up sometimes. This commit resolves this issue by setting TMPDIR to /data/tmp on the taskrunners.