### PR TITLE
Deactivate fail-fast option on image build workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: ["validate"]
     strategy:
+      fail-fast: false
       matrix:
         machine: [backend, taskrunner, cron, sftp]
         environment:


### PR DESCRIPTION
Currently, we have a problem where if our image builds fail, several EC2 instances that were supposed to run temporarily for the image builds never get shut down, costing us money. The reason for this is that while packer cleans up the actual failing instance, with the fail fast option enabled (as it is by default) Github then cancels the other 11 tasks before they can fail (or succeed) and trigger packer's cleanup process. This commit alleviates this problem by disabling the fail-fast option.